### PR TITLE
🧹 Remove unused variable in Spec2GraphDiffusion.forward

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -574,7 +574,7 @@ class Spec2GraphDiffusion(nn.Module):
         Returns:
             Predicted noise, shape (batch, n_atoms, k)
         """
-        batch_size, n_atoms, _ = x_t.shape
+        _, n_atoms, _ = x_t.shape
 
         if n_atoms > self.max_atoms:
             raise ValueError(


### PR DESCRIPTION
🎯 **What:** Removed the unused `batch_size` variable by replacing it with an underscore `_` in `Spec2GraphDiffusion.forward`.
💡 **Why:** `batch_size` was unused and removing it improves code health. This makes the code cleaner and less confusing.
✅ **Verification:** Verified by confirming all `pytest` tests pass successfully with the fix.
✨ **Result:** Improved codebase readability by cleanly handling unpacking without warnings.

---
*PR created automatically by Jules for task [9445277604948849559](https://jules.google.com/task/9445277604948849559) started by @CodeHalwell*