### PR TITLE
🧹 Remove unused batch_size variable in DenseGNNDiscriminator

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -1390,7 +1390,7 @@ class DenseGNNDiscriminator(nn.Module):
         Returns:
             Validity scores, shape (batch, 1)
         """
-        batch_size, n_atoms, _ = adj_probs.shape
+        _, n_atoms, _ = adj_probs.shape
 
         # Use node degree as initial features
         degree = adj_probs.sum(dim=-1, keepdim=True)  # (batch, n_atoms, 1)


### PR DESCRIPTION
🎯 **What:** Replaced unused `batch_size` variable assignment with `_` when unpacking `adj_probs.shape` in `DenseGNNDiscriminator.forward` of `spectral_diffusion.py`.
💡 **Why:** Eliminates dead code and follows the established convention of using `_` for unused variables when unpacking tensor shapes, making it explicit that the variable is intentionally ignored and improving code readability.
✅ **Verification:** Ran the full `tests/` suite using `python -m pytest` which completed successfully with 52/52 passing tests, ensuring no functionality was altered.
✨ **Result:** Cleaner code in `spectral_diffusion.py` by removing an unused variable assignment.

---
*PR created automatically by Jules for task [6955670538757876151](https://jules.google.com/task/6955670538757876151) started by @CodeHalwell*