### PR TITLE
🧪 Add test coverage for predict_atom_count enabled and disabled states

### DIFF
--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -603,6 +603,34 @@ class TestValencyDecoder:
 
 
 # ==============================================================================
+# Atom Count Head Tests
+# ==============================================================================
+
+
+class TestAtomCountHead:
+    def test_atom_count_head_prediction_shape(self):
+        model = Spec2GraphDiffusion(
+            k=4, max_atoms=8, max_peaks=10, d_model=32, nhead=4,
+            num_encoder_layers=1, num_decoder_layers=1,
+            enable_atom_count_head=True
+        )
+        mz = torch.randn(2, 10)
+        intensity = torch.randn(2, 10)
+        pred = model.predict_atom_count(mz, intensity)
+        assert pred.shape == (2,)
+
+    def test_atom_count_head_disabled_raises(self):
+        model = Spec2GraphDiffusion(
+            k=4, max_atoms=8, max_peaks=10, d_model=32, nhead=4,
+            enable_atom_count_head=False
+        )
+        mz = torch.randn(1, 10)
+        intensity = torch.randn(1, 10)
+        with pytest.raises(ValueError, match="Atom count head is disabled"):
+            model.predict_atom_count(mz, intensity)
+
+
+# ==============================================================================
 # Eigenvalue Conditioning Tests (Phase 4, Section 8)
 # ==============================================================================
 


### PR DESCRIPTION
🎯 **What:** 
Added unit tests to `tests/test_spec2graph.py` to cover the `predict_atom_count` method of the `Spec2GraphDiffusion` model, addressing a gap in testing its conditional behavior.

📊 **Coverage:**
The added test suite `TestAtomCountHead` handles two scenarios:
1. When `enable_atom_count_head=False`, it validates that calling `predict_atom_count(mz, intensity)` properly throws a `ValueError` indicating the module is disabled.
2. When `enable_atom_count_head=True`, it verifies that the method computes the expected tensor shape appropriately using provided `mz` and `intensity` parameters.

✨ **Result:**
Test coverage has increased and ensures no unintended crashes or incorrect behavior result from misconfigured settings regarding the `atom_count_head`.

---
*PR created automatically by Jules for task [17164952111698085444](https://jules.google.com/task/17164952111698085444) started by @CodeHalwell*