### PR TITLE
🧪 [Testing Improvement] Add Invalid SMILES test for smiles_to_adjacency

### DIFF
--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -101,6 +101,13 @@ def test_q_sample_reconstruct_is_stable():
     assert torch.allclose(x0, reconstructed, atol=1e-5)
 
 
+
+def test_smiles_to_adjacency_invalid_smiles():
+    processor = SpectralDataProcessor()
+    with pytest.raises(ValueError, match="Invalid SMILES: invalid"):
+        processor.smiles_to_adjacency("invalid")
+
+
 def test_bond_weighting_distinguishes_double_bond():
     single = SpectralDataProcessor(bond_weighting="order").smiles_to_adjacency("CC")
     double = SpectralDataProcessor(bond_weighting="order").smiles_to_adjacency("C=C")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test for handling invalid SMILES strings in `smiles_to_adjacency`.
📊 **Coverage:** What scenarios are now tested: A test case has been added to ensure that an invalid string appropriately triggers a `ValueError` with the expected message.
✨ **Result:** The improvement in test coverage: We have greater confidence that the system properly catches and handles unparseable SMILES inputs.

---
*PR created automatically by Jules for task [6028131553092168252](https://jules.google.com/task/6028131553092168252) started by @CodeHalwell*