### PR TITLE
🧹 [code health] Remove unused k variable in EigenvalueConditionedSGNO

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -1760,7 +1760,7 @@ class EigenvalueConditionedSGNO(nn.Module):
         Returns:
             Symmetric adjacency logits, shape (batch, n_atoms, n_atoms)
         """
-        batch_size, n_atoms, k = embeddings.shape
+        batch_size, n_atoms, _ = embeddings.shape
 
         # Encode eigenvalues
         eig_cond = self.eigenvalue_encoder(eigenvalues)  # (batch, eigenvalue_dim)


### PR DESCRIPTION
🎯 **What:** Removed the unused `k` variable in `EigenvalueConditionedSGNO.forward` during tuple unpacking.
💡 **Why:** Straightforward dead code removal. This cleans up the code and avoids linters complaining about an unused variable, slightly improving readability and adhering to codebase conventions.
✅ **Verification:** Verified by running the existing test suite (`python3 -m pytest tests/test_spec2graph.py`), which passes entirely, confirming no functional regression.
✨ **Result:** A cleaner method signature without unused bindings.

---
*PR created automatically by Jules for task [404080558279904033](https://jules.google.com/task/404080558279904033) started by @CodeHalwell*