### PR TITLE
🧹 [Code Health] Refactor `compute_loss` and `train_step` to use `TrainingBatch` dataclass

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -26,6 +26,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from typing import Dict, List, Tuple, Optional, Union
+from dataclasses import dataclass
 import warnings
 
 # Numerical floor to avoid divide-by-zero when reconstructing clean samples
@@ -691,6 +692,20 @@ class Spec2GraphDiffusion(nn.Module):
         return self.eigenvalue_head(pooled)
 
 
+@dataclass
+class TrainingBatch:
+    """A batch of training data containing molecular graph components and mass spectra."""
+    x_0: torch.Tensor
+    mz: torch.Tensor
+    intensity: torch.Tensor
+    atom_mask: Optional[torch.Tensor] = None
+    spectrum_mask: Optional[torch.Tensor] = None
+    precursor_mz: Optional[torch.Tensor] = None
+    fingerprint_targets: Optional[torch.Tensor] = None
+    atom_count_targets: Optional[torch.Tensor] = None
+    eigenvalue_targets: Optional[torch.Tensor] = None
+
+
 class DiffusionTrainer:
     """Training and sampling utilities for DDPM diffusion."""
 
@@ -1009,35 +1024,29 @@ class DiffusionTrainer:
 
     def compute_loss(
         self,
-        x_0: torch.Tensor,
-        mz: torch.Tensor,
-        intensity: torch.Tensor,
-        atom_mask: Optional[torch.Tensor] = None,
-        spectrum_mask: Optional[torch.Tensor] = None,
-        precursor_mz: Optional[torch.Tensor] = None,
-        fingerprint_targets: Optional[torch.Tensor] = None,
-        atom_count_targets: Optional[torch.Tensor] = None,
-        eigenvalue_targets: Optional[torch.Tensor] = None,
+        batch: TrainingBatch,
         return_components: bool = False,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, dict]]:
         """
         Compute training loss.
 
         Args:
-            x_0: Clean eigenvectors, shape (batch, n_atoms, k)
-            mz: m/z values, shape (batch, n_peaks)
-            intensity: Intensity values, shape (batch, n_peaks)
-            atom_mask: Optional atom mask
-            spectrum_mask: Optional spectrum mask
-            precursor_mz: Optional precursor m/z values
-            fingerprint_targets: Optional fingerprint labels for auxiliary loss
-            atom_count_targets: Optional atom-count labels for auxiliary loss
-            eigenvalue_targets: Optional eigenvalue labels for Phase 4 auxiliary loss
+            batch: TrainingBatch containing inputs and targets
             return_components: If True, also return component losses
 
         Returns:
             MSE loss
         """
+        x_0 = batch.x_0
+        mz = batch.mz
+        intensity = batch.intensity
+        atom_mask = batch.atom_mask
+        spectrum_mask = batch.spectrum_mask
+        precursor_mz = batch.precursor_mz
+        fingerprint_targets = batch.fingerprint_targets
+        atom_count_targets = batch.atom_count_targets
+        eigenvalue_targets = batch.eigenvalue_targets
+
         batch_size = x_0.shape[0]
 
         # Sample random timesteps
@@ -1128,31 +1137,15 @@ class DiffusionTrainer:
     def train_step(
         self,
         optimizer: torch.optim.Optimizer,
-        x_0: torch.Tensor,
-        mz: torch.Tensor,
-        intensity: torch.Tensor,
-        atom_mask: Optional[torch.Tensor] = None,
-        spectrum_mask: Optional[torch.Tensor] = None,
-        precursor_mz: Optional[torch.Tensor] = None,
-        fingerprint_targets: Optional[torch.Tensor] = None,
-        atom_count_targets: Optional[torch.Tensor] = None,
-        eigenvalue_targets: Optional[torch.Tensor] = None,
+        batch: TrainingBatch,
         return_components: bool = False,
     ) -> Union[float, Tuple[float, dict]]:
         """
         Single training step.
 
         Args:
-            optimizer: Optimizer
-            x_0: Clean eigenvectors
-            mz: m/z values
-            intensity: Intensity values
-            atom_mask: Optional atom mask
-            spectrum_mask: Optional spectrum mask
-            precursor_mz: Optional precursor m/z values
-            fingerprint_targets: Optional fingerprint labels
-            atom_count_targets: Optional atom-count labels
-            eigenvalue_targets: Optional eigenvalue labels for Phase 4 loss
+            optimizer: PyTorch optimizer
+            batch: TrainingBatch containing inputs and targets
             return_components: If True, also return component losses
 
         Returns:
@@ -1163,29 +1156,13 @@ class DiffusionTrainer:
 
         loss, components = (
             self.compute_loss(
-                x_0,
-                mz,
-                intensity,
-                atom_mask,
-                spectrum_mask,
-                precursor_mz,
-                fingerprint_targets,
-                atom_count_targets,
-                eigenvalue_targets,
+                batch,
                 return_components=True,
             )
             if return_components
             else (
                 self.compute_loss(
-                    x_0,
-                    mz,
-                    intensity,
-                    atom_mask,
-                    spectrum_mask,
-                    precursor_mz,
-                    fingerprint_targets,
-                    atom_count_targets,
-                    eigenvalue_targets,
+                    batch,
                     return_components=False,
                 ),
                 None,
@@ -1936,16 +1913,22 @@ def run_demo():
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
 
     n_steps = 20
+
+    # Create training batch
+    batch = TrainingBatch(
+        x_0=x_0,
+        mz=mz,
+        intensity=intensity,
+        atom_mask=atom_mask,
+        spectrum_mask=spectrum_mask,
+        fingerprint_targets=fp_targets,
+        atom_count_targets=atom_counts,
+    )
+
     for step in range(n_steps):
         loss, components = trainer.train_step(
             optimizer,
-            x_0,
-            mz,
-            intensity,
-            atom_mask=atom_mask,
-            spectrum_mask=spectrum_mask,
-            fingerprint_targets=fp_targets,
-            atom_count_targets=atom_counts,
+            batch,
             return_components=True,
         )
         if (step + 1) % 5 == 0:

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 
 from spectral_diffusion import (
+    TrainingBatch,
     DiffusionTrainer,
     SpectralDataProcessor,
     Spec2GraphDiffusion,
@@ -219,7 +220,8 @@ class TestOrthonormalityLoss:
         x_0 = torch.randn(2, 4, 2)
         mz = torch.randn(2, 4)
         intensity = torch.randn(2, 4)
-        _, components = trainer.compute_loss(x_0, mz, intensity, return_components=True)
+        batch = TrainingBatch(x_0=x_0, mz=mz, intensity=intensity)
+        _, components = trainer.compute_loss(batch, return_components=True)
         assert "orthonormality" in components
         # Should be non-negative
         assert components["orthonormality"].item() >= 0
@@ -231,7 +233,8 @@ class TestOrthonormalityLoss:
         x_0 = torch.randn(2, 4, 2)
         mz = torch.randn(2, 4)
         intensity = torch.randn(2, 4)
-        _, components = trainer.compute_loss(x_0, mz, intensity, return_components=True)
+        batch = TrainingBatch(x_0=x_0, mz=mz, intensity=intensity)
+        _, components = trainer.compute_loss(batch, return_components=True)
         assert components["orthonormality"].item() == 0.0
 
 
@@ -308,13 +311,11 @@ class TestPrecursorConditioning:
 
         with torch.no_grad():
             torch.manual_seed(7)
-            loss_low = trainer.compute_loss(
-                x_0, mz, intensity, precursor_mz=torch.tensor([100.0])
-            )
+            batch_low = TrainingBatch(x_0=x_0, mz=mz, intensity=intensity, precursor_mz=torch.tensor([100.0]))
+            loss_low = trainer.compute_loss(batch_low)
             torch.manual_seed(7)
-            loss_high = trainer.compute_loss(
-                x_0, mz, intensity, precursor_mz=torch.tensor([500.0])
-            )
+            batch_high = TrainingBatch(x_0=x_0, mz=mz, intensity=intensity, precursor_mz=torch.tensor([500.0]))
+            loss_high = trainer.compute_loss(batch_high)
 
         assert torch.isfinite(loss_low)
         assert torch.isfinite(loss_high)
@@ -684,11 +685,8 @@ class TestEigenvalueConditioning:
         mz = torch.randn(2, 4)
         intensity = torch.randn(2, 4)
         eigenvalue_targets = torch.randn(2, 2)
-        _, components = trainer.compute_loss(
-            x_0, mz, intensity,
-            eigenvalue_targets=eigenvalue_targets,
-            return_components=True
-        )
+        batch = TrainingBatch(x_0=x_0, mz=mz, intensity=intensity, eigenvalue_targets=eigenvalue_targets)
+        _, components = trainer.compute_loss(batch, return_components=True)
         assert "eigenvalue" in components
         assert components["eigenvalue"].item() > 0
 
@@ -750,11 +748,16 @@ class TestEndToEndPipeline:
         ac = torch.tensor([4.0, 3.0])
         ev = torch.randn(2, 2)
 
-        loss_val, components = trainer.train_step(
-            optimizer, x_0, mz, intensity,
-            fingerprint_targets=fp, atom_count_targets=ac,
+        batch = TrainingBatch(
+            x_0=x_0,
+            mz=mz,
+            intensity=intensity,
+            fingerprint_targets=fp,
+            atom_count_targets=ac,
             eigenvalue_targets=ev,
-            return_components=True
+        )
+        loss_val, components = trainer.train_step(
+            optimizer, batch, return_components=True
         )
         assert isinstance(loss_val, float)
         assert loss_val > 0


### PR DESCRIPTION
🎯 **What:** Introduced a `TrainingBatch` dataclass to encapsulate training data. Updated `DiffusionTrainer.compute_loss` and `DiffusionTrainer.train_step` to accept this dataclass instead of 9 individual tensor arguments. Updated dummy loop and tests accordingly.
💡 **Why:** Significantly improves the readability and maintainability of the codebase by consolidating parameters into a single batch object. Reduces function signature complexity.
✅ **Verification:** Ran `python3 -m pytest` confirming all 52 tests are passing.
✨ **Result:** A cleaner interface for training methods while preserving functionality.

---
*PR created automatically by Jules for task [17136426440003399167](https://jules.google.com/task/17136426440003399167) started by @CodeHalwell*