### PR TITLE
🧪 [testing] Add validation and test for missing atoms in process_smiles

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -87,6 +87,10 @@ class SpectralDataProcessor:
             raise ValueError(f"Invalid SMILES: {smiles}")
 
         num_atoms = mol.GetNumAtoms()
+        if num_atoms == 0:
+            raise ValueError(
+                f"SMILES {smiles} resulted in 0 atoms after adding Hs."
+            )
         adjacency = np.zeros((num_atoms, num_atoms), dtype=np.float32)
 
         for bond in mol.GetBonds():

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -762,3 +762,10 @@ class TestEndToEndPipeline:
             "noise", "projection", "orthonormality", "fingerprint", "atom_count",
             "eigenvalue"
         ])
+
+def test_process_smiles_zero_atoms():
+    from spectral_diffusion import SpectralDataProcessor
+    import pytest
+    processor = SpectralDataProcessor()
+    with pytest.raises(ValueError, match="resulted in 0 atoms after adding Hs"):
+        processor.process_smiles("")


### PR DESCRIPTION
🎯 **What:** Added a validation check to `smiles_to_adjacency` to raise a `ValueError` if parsing a SMILES string results in a molecule with 0 atoms.
📊 **Coverage:** Added `test_process_smiles_zero_atoms` to `tests/test_spec2graph.py` which passes an empty string `""` to verify that the `ValueError` with the expected message is correctly raised.
✨ **Result:** Test coverage is improved and invalid molecules will fail early rather than generating silent empty matrices or downstream errors.

---
*PR created automatically by Jules for task [17571619571527309457](https://jules.google.com/task/17571619571527309457) started by @CodeHalwell*