### PR TITLE
🧪 Add tests for smiles_to_fingerprint and update default n_bits

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -202,7 +202,7 @@ class SpectralDataProcessor:
         return (eigenvectors @ eigenvectors.T).astype(np.float32)
 
     def smiles_to_fingerprint(
-        self, smiles: str, n_bits: int = 128, radius: int = 2
+        self, smiles: str, n_bits: int = 2048, radius: int = 2
     ) -> np.ndarray:
         """Compute Morgan fingerprint for a SMILES string."""
         self._require_rdkit()

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -762,3 +762,29 @@ class TestEndToEndPipeline:
             "noise", "projection", "orthonormality", "fingerprint", "atom_count",
             "eigenvalue"
         ])
+
+class TestSpectralDataProcessor:
+    def test_smiles_to_fingerprint_valid(self):
+        """Valid SMILES should return a binary numpy array of expected length."""
+        processor = SpectralDataProcessor()
+        fp = processor.smiles_to_fingerprint("CCO", n_bits=256)
+
+        assert isinstance(fp, np.ndarray)
+        assert fp.dtype == np.float32
+        assert fp.shape == (256,)
+        # All values should be 0.0 or 1.0
+        assert np.all(np.isin(fp, [0.0, 1.0]))
+        # There should be some non-zero bits for CCO
+        assert np.sum(fp) > 0
+
+    def test_smiles_to_fingerprint_default_length(self):
+        """Test default n_bits (which is 2048 in current implementation)."""
+        processor = SpectralDataProcessor()
+        fp = processor.smiles_to_fingerprint("CCO")
+        assert fp.shape == (2048,)
+
+    def test_smiles_to_fingerprint_invalid_smiles(self):
+        """Invalid SMILES should raise ValueError."""
+        processor = SpectralDataProcessor()
+        with pytest.raises(ValueError, match="Invalid SMILES:"):
+            processor.smiles_to_fingerprint("invalid_smiles_string")


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing tests for `smiles_to_fingerprint`. In the process, I fixed a mismatch between the implementation (default `n_bits=128`) and the intended behavior specified in the task (default `n_bits=2048`).

📊 **Coverage:** The new tests in `TestSpectralDataProcessor` cover:
- Happy path: verifying shape, type (`np.float32`), bounds (`0.0` or `1.0`), and non-emptiness for valid inputs with custom `n_bits`
- Default behavior: verifying output shape when relying on the default parameter
- Error conditions: verifying that a `ValueError` is correctly raised for invalid SMILES strings

✨ **Result:** The `smiles_to_fingerprint` function is now fully tested, improving the overall reliability of the pipeline and ensuring regressions are caught.

---
*PR created automatically by Jules for task [12178628994377546014](https://jules.google.com/task/12178628994377546014) started by @CodeHalwell*