### PR TITLE
🧪 Add mask length validation check and test cases

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -489,13 +489,13 @@ class Spec2GraphDiffusion(nn.Module):
             self.precursor_fusion = nn.Linear(d_model * 2, d_model)
 
     @staticmethod
-    def _validate_mask(mask: torch.Tensor, name: str) -> None:
+    def _validate_mask(mask: torch.Tensor, name: str, expected_length: Optional[int] = None) -> None:
         """Ensure masks follow the True=valid convention and have at least one valid token."""
         if mask.dtype != torch.bool:
             raise ValueError(f"{name} must be a boolean tensor with True indicating valid entries.")
-        if mask.dim() < 2:
+        if mask.dim() != 2 or (expected_length is not None and mask.shape[1] != expected_length):
             raise ValueError(f"{name} must have shape (batch, length); got {mask.shape}.")
-        if torch.any(mask.sum(dim=1) == 0):
+        if not mask.any(dim=1).all():
             raise ValueError(f"{name} must contain at least one valid element per batch item.")
 
     def encode_spectrum(
@@ -524,7 +524,7 @@ class Spec2GraphDiffusion(nn.Module):
 
         # Apply transformer encoder
         if mask is not None:
-            self._validate_mask(mask, "spectrum_mask")
+            self._validate_mask(mask, "spectrum_mask", expected_length=mz.shape[1])
             # Convert to attention mask format (True = ignore)
             src_key_padding_mask = ~mask
         else:
@@ -601,7 +601,7 @@ class Spec2GraphDiffusion(nn.Module):
 
         # Prepare masks
         if atom_mask is not None:
-            self._validate_mask(atom_mask, "atom_mask")
+            self._validate_mask(atom_mask, "atom_mask", expected_length=n_atoms)
             tgt_key_padding_mask = ~atom_mask
         else:
             tgt_key_padding_mask = None

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -84,6 +84,20 @@ def test_forward_raises_when_atoms_exceed_max():
         model(x_t, t, mz, intensity)
 
 
+
+def test_forward_raises_when_mask_length_invalid():
+    """Verify that an atom mask with length != max_atoms raises a ValueError."""
+    model = Spec2GraphDiffusion(k=2, max_atoms=4, max_peaks=4)
+    # x_t length matches max_atoms, but atom_mask has length 5
+    x_t = torch.randn(1, 4, 2)
+    t = torch.zeros(1, dtype=torch.long)
+    mz = torch.zeros(1, 4)
+    intensity = torch.zeros(1, 4)
+    atom_mask = torch.ones(1, 5, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="atom_mask must have shape"):
+        model(x_t, t, mz, intensity, atom_mask=atom_mask)
+
 def test_q_sample_reconstruct_is_stable():
     model = Spec2GraphDiffusion(k=2, max_atoms=4, max_peaks=4)
     trainer = DiffusionTrainer(model, n_timesteps=5)


### PR DESCRIPTION
🎯 **What:** The `_validate_mask` function missed a length consistency check for length parameter `expected_length`, rendering test coverage incomplete as pointed out in issue.
📊 **Coverage:** A test `test_forward_raises_when_mask_length_invalid` is added, verifying that a `ValueError` triggers when the given `atom_mask`'s length fails to match the `expected_length` parameters (or input sizes).
✨ **Result:** Both the `_validate_mask` implementation and the coverage has been improved effectively ensuring more stable and secure data inputs to tensor operations.

---
*PR created automatically by Jules for task [15732616542292080767](https://jules.google.com/task/15732616542292080767) started by @CodeHalwell*