### PR TITLE
🧪 [Testing Improvement] Support custom start point in sample()

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -953,6 +953,7 @@ class DiffusionTrainer:
         atom_mask: Optional[torch.Tensor] = None,
         spectrum_mask: Optional[torch.Tensor] = None,
         precursor_mz: Optional[torch.Tensor] = None,
+        x_t: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Generate eigenvectors by reverse diffusion.
@@ -996,8 +997,12 @@ class DiffusionTrainer:
                 f"Requested n_atoms ({n_atoms}) exceeds model.max_atoms ({self.model.max_atoms})."
             )
 
-        # Start from pure noise
-        x_t = torch.randn(batch_size, n_atoms, k, device=self.device)
+        if x_t is not None:
+            if x_t.shape != (batch_size, n_atoms, k):
+                raise ValueError(f"Expected x_t shape {(batch_size, n_atoms, k)}, but got {x_t.shape}")
+        else:
+            # Start from pure noise
+            x_t = torch.randn(batch_size, n_atoms, k, device=self.device)
 
         # Reverse diffusion
         for t in reversed(range(self.n_timesteps)):

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -101,6 +101,41 @@ def test_q_sample_reconstruct_is_stable():
     assert torch.allclose(x0, reconstructed, atol=1e-5)
 
 
+
+
+def test_sample_custom_start_point():
+    model = Spec2GraphDiffusion(k=2, max_atoms=4, max_peaks=4)
+    trainer = DiffusionTrainer(model, n_timesteps=5)
+
+    mz = torch.rand(1, 4)
+    intensity = torch.rand(1, 4)
+    n_atoms = 3
+
+    # Custom x_t
+    x_t_custom = torch.randn(1, 3, 2)
+
+    # Call sample with custom x_t
+    result = trainer.sample(mz, intensity, n_atoms=n_atoms, x_t=x_t_custom)
+
+    assert result.shape == (1, 3, 2)
+    assert torch.all(torch.isfinite(result))
+
+
+def test_sample_custom_start_point_shape_mismatch():
+    model = Spec2GraphDiffusion(k=2, max_atoms=4, max_peaks=4)
+    trainer = DiffusionTrainer(model, n_timesteps=5)
+
+    mz = torch.rand(1, 4)
+    intensity = torch.rand(1, 4)
+    n_atoms = 3
+
+    # Custom x_t with incorrect shape (batch_size=2 instead of 1)
+    x_t_custom = torch.randn(2, 3, 2)
+
+    # Should raise ValueError due to shape mismatch
+    with pytest.raises(ValueError, match="Expected x_t shape"):
+        trainer.sample(mz, intensity, n_atoms=n_atoms, x_t=x_t_custom)
+
 def test_bond_weighting_distinguishes_double_bond():
     single = SpectralDataProcessor(bond_weighting="order").smiles_to_adjacency("CC")
     double = SpectralDataProcessor(bond_weighting="order").smiles_to_adjacency("C=C")


### PR DESCRIPTION
🎯 **What:** Modified `SpectralDiffusionTrainer.sample` to accept a custom start point `x_t` and added validation to ensure the shape matches `(batch_size, n_atoms, k)`.
📊 **Coverage:** Added two tests:
- `test_sample_custom_start_point`: Verifies the sample method processes a custom `x_t` accurately and outputs finite values without error.
- `test_sample_custom_start_point_shape_mismatch`: Verifies that an invalid tensor shape correctly triggers a `ValueError`.
✨ **Result:** Test coverage for providing custom starting points in reverse diffusion generation has been successfully achieved, preventing unexpected shape mismatches and ensuring reliable downstream execution.

---
*PR created automatically by Jules for task [5102010092902304593](https://jules.google.com/task/5102010092902304593) started by @CodeHalwell*