### PR TITLE
🧪 [Testing] Add tests for _validate_mask method in Spec2GraphDiffusion

### DIFF
--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -762,3 +762,32 @@ class TestEndToEndPipeline:
             "noise", "projection", "orthonormality", "fingerprint", "atom_count",
             "eigenvalue"
         ])
+
+class TestValidateMask:
+    def test_validate_mask_correct(self):
+        """Valid masks should pass without raising exceptions."""
+        mask = torch.tensor([[True, True], [False, True]], dtype=torch.bool)
+        # Should not raise
+        Spec2GraphDiffusion._validate_mask(mask, "test_mask")
+
+    def test_validate_mask_wrong_dtype(self):
+        """Non-boolean masks should raise ValueError."""
+        mask = torch.tensor([[1, 0], [0, 1]], dtype=torch.int)
+        with pytest.raises(ValueError, match="must be a boolean tensor"):
+            Spec2GraphDiffusion._validate_mask(mask, "test_mask")
+
+        mask_float = torch.tensor([[1.0, 0.0], [0.0, 1.0]], dtype=torch.float)
+        with pytest.raises(ValueError, match="must be a boolean tensor"):
+            Spec2GraphDiffusion._validate_mask(mask_float, "test_mask")
+
+    def test_validate_mask_wrong_dim(self):
+        """Masks with fewer than 2 dimensions should raise ValueError."""
+        mask = torch.tensor([True, False], dtype=torch.bool)
+        with pytest.raises(ValueError, match="must have shape \\(batch, length\\)"):
+            Spec2GraphDiffusion._validate_mask(mask, "test_mask")
+
+    def test_validate_mask_all_false(self):
+        """Masks where any batch item has all False entries should raise ValueError."""
+        mask = torch.tensor([[True, False], [False, False]], dtype=torch.bool)
+        with pytest.raises(ValueError, match="must contain at least one valid element"):
+            Spec2GraphDiffusion._validate_mask(mask, "test_mask")


### PR DESCRIPTION
## 🎯 What
This PR addresses an untested validation method (`_validate_mask`) in the `Spec2GraphDiffusion` class. The method is critical for validating spectrum and atom masks during the forward pass, ensuring they adhere to the correct data type (boolean), dimensionality (at least 2D), and validity (at least one valid entry per batch item). 

## 📊 Coverage
The newly added `TestValidateMask` class ensures coverage for the following scenarios:
* **Valid Mask:** Verifies that a structurally sound boolean mask with valid entries does not raise exceptions.
* **Wrong Data Type (`ValueError`):** Checks that masks instantiated as integers or floats trigger a `ValueError`.
* **Incorrect Dimensionality (`ValueError`):** Ensures that 1D arrays raise an exception, explicitly catching masks that miss the required `(batch, length)` structure.
* **Missing Valid Tokens (`ValueError`):** Verifies that masks where an entire batch item consists entirely of `False` (no valid tokens) are correctly rejected.

## ✨ Result
Increased unit testing coverage specifically addressing error-handling for graph diffusion data preprocessing. Prevents regressions in mask preprocessing and helps surface faulty configurations earlier in the pipeline.

---
*PR created automatically by Jules for task [7615705644762822101](https://jules.google.com/task/7615705644762822101) started by @CodeHalwell*