### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability via input length limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Missing length limits on inputs
+**Vulnerability:** Methods processing SMILES strings and Mass Spectrum data did not have sufficient length limits. `SpectralDataProcessor.smiles_to_adjacency` and `smiles_to_fingerprint` pass strings to RDKit, which could be extremely large and cause a Denial of Service (DoS) by hogging CPU/Memory. `Spec2GraphDiffusion.encode_spectrum` processes `mz` and `intensity` sequences via a Transformer, which has O(N^2) complexity with sequence length. Although `max_peaks` is configured, it wasn't validated in `encode_spectrum`.
+**Learning:** External dependencies like RDKit and O(N^2) architectures like Transformers are sensitive to unbounded inputs. Even if the expected input is typically small, missing hard limits opens vectors for DoS.
+**Prevention:** Always implement hard input length boundaries before passing data into external parsing libraries or computationally complex operations.

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -83,6 +83,9 @@ class SpectralDataProcessor:
             Adjacency matrix as numpy array
         """
         self._require_rdkit()
+        # Security enhancement: Limit SMILES length to prevent DoS via excessive processing
+        if not isinstance(smiles, str) or len(smiles) > 2000:
+            raise ValueError("SMILES must be a string of reasonable length (<= 2000 characters).")
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
@@ -223,6 +226,9 @@ class SpectralDataProcessor:
     ) -> np.ndarray:
         """Compute Morgan fingerprint for a SMILES string."""
         self._require_rdkit()
+        # Security enhancement: Limit SMILES length to prevent DoS via excessive processing
+        if not isinstance(smiles, str) or len(smiles) > 2000:
+            raise ValueError("SMILES must be a string of reasonable length (<= 2000 characters).")
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
@@ -535,6 +541,13 @@ class Spec2GraphDiffusion(nn.Module):
         Returns:
             Encoded spectrum, shape (batch, n_peaks, d_model)
         """
+        # Security enhancement: Validate input lengths to prevent O(N^2) memory exhaustion (DoS)
+        if mz.shape[1] > self.max_peaks:
+            raise ValueError(
+                f"Number of peaks ({mz.shape[1]}) exceeds configured max_peaks ({self.max_peaks}). "
+            )
+        if mz.shape != intensity.shape:
+            raise ValueError(f"mz and intensity shapes must match, got {mz.shape} and {intensity.shape}")
         # Combine m/z and intensity embeddings
         mz_emb = self.mz_embedding(mz)
         int_emb = self.intensity_embedding(intensity)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded input lengths when processing SMILES strings via RDKit and peak arrays via the `Spec2GraphDiffusion` transformer encoder created vectors for Denial of Service (DoS) via resource exhaustion (O(N^2) memory complexity or runaway parsing).
🎯 **Impact:** An attacker could supply arbitrarily large SMILES strings or spectrum arrays, crashing the application with Out-of-Memory errors or tying up CPU cycles indefinitely.
🔧 **Fix:** Added explicit input length bounds checking on SMILES strings (<= 2000 characters) and validated that input sequence arrays do not exceed the model's configured `max_peaks`.
✅ **Verification:** Verified by running the test suite (`pytest`), ensuring that all existing functionality continues to work correctly, and checking changes with `git diff`.

---
*PR created automatically by Jules for task [7161016988318068507](https://jules.google.com/task/7161016988318068507) started by @CodeHalwell*