### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerabilities via memory exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Input Length Limits
+**Vulnerability:** The application did not restrict the length of SMILES strings parsed by RDKit or the number of peaks (`mz` arrays) passed into O(N^2) complexity Transformer modules.
+**Learning:** External inputs like strings passed to parsers and large arrays given to O(N^2) complexity modules can lead to memory exhaustion and cause a Denial of Service (DoS).
+**Prevention:** Always enforce hard length limits on input strings directly tied to parsers or memory-heavy components like Transformers.

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -83,6 +83,8 @@ class SpectralDataProcessor:
             Adjacency matrix as numpy array
         """
         self._require_rdkit()
+        if len(smiles) > 5000:
+            raise ValueError("SMILES string too long (exceeds 5000 characters).")
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
@@ -223,6 +225,8 @@ class SpectralDataProcessor:
     ) -> np.ndarray:
         """Compute Morgan fingerprint for a SMILES string."""
         self._require_rdkit()
+        if len(smiles) > 5000:
+            raise ValueError("SMILES string too long (exceeds 5000 characters).")
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
@@ -535,6 +539,9 @@ class Spec2GraphDiffusion(nn.Module):
         Returns:
             Encoded spectrum, shape (batch, n_peaks, d_model)
         """
+        if mz.shape[1] > self.max_peaks:
+            raise ValueError(f"Number of peaks ({mz.shape[1]}) exceeds configured max_peaks ({self.max_peaks}).")
+
         # Combine m/z and intensity embeddings
         mz_emb = self.mz_embedding(mz)
         int_emb = self.intensity_embedding(intensity)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was missing length limits on user-provided SMILES strings processed by RDKit, and limits on the number of Mass Spectrum peaks (`mz` arrays) passed into O(N^2) memory complexity Transformer layers.
🎯 Impact: An attacker could intentionally submit an extremely long SMILES string or a massive spectrum, triggering memory exhaustion and potentially crashing the server (Denial of Service).
🔧 Fix: Added explicit length validation (`<= 5000` chars) for SMILES strings in `smiles_to_adjacency` and `smiles_to_fingerprint`. Also, added a check in `encode_spectrum` ensuring the number of peaks does not exceed `max_peaks`.
✅ Verification: Ran the full test suite to ensure that these validation additions did not break existing expected functionality. Recorded this learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2055202090916690604](https://jules.google.com/task/2055202090916690604) started by @CodeHalwell*