### PR TITLE
⚡ Bolt: [performance improvement] Optimize TimestepEmbedding

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -353,6 +353,17 @@ class TimestepEmbedding(nn.Module):
         self.d_model = d_model
         self.max_period = max_period
 
+        # OPTIMIZATION: Precompute frequencies and register as buffer
+        # to avoid allocation and calculation on every forward pass.
+        # Use persistent=False to avoid backward compatibility issues with state_dicts.
+        half_dim = self.d_model // 2
+        freqs = torch.exp(
+            -math.log(self.max_period)
+            * torch.arange(half_dim, dtype=torch.float32)
+            / half_dim
+        )
+        self.register_buffer("freqs", freqs, persistent=False)
+
         self.mlp = nn.Sequential(
             nn.Linear(d_model, d_model * 4),
             nn.GELU(),
@@ -369,13 +380,7 @@ class TimestepEmbedding(nn.Module):
         Returns:
             Embedding of shape (batch, d_model)
         """
-        half_dim = self.d_model // 2
-        freqs = torch.exp(
-            -math.log(self.max_period)
-            * torch.arange(half_dim, device=t.device, dtype=torch.float32)
-            / half_dim
-        )
-        args = t.float().unsqueeze(-1) * freqs
+        args = t.float().unsqueeze(-1) * self.freqs
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
 
         if self.d_model % 2 == 1:


### PR DESCRIPTION
💡 What: Precompute and register `freqs` tensor as a non-persistent buffer in `TimestepEmbedding.__init__`.
🎯 Why: Previously, the `freqs` tensor was dynamically calculated in the `forward` pass, allocating memory and performing computations on every iteration.
📊 Impact: Eliminates redundant tensor allocations and math operations (`exp`, `log`, `arange`, etc.) on every forward pass, slightly improving training and inference speed.
🔬 Measurement: Verify tests run via `PYTHONPATH=. pytest` and profiling during training runs will reflect reduced latency in the `forward` method.

---
*PR created automatically by Jules for task [14481621894850516436](https://jules.google.com/task/14481621894850516436) started by @CodeHalwell*