### PR TITLE
🛡️ Sentinel: [HIGH] Fix zero-atom parsing vulnerability in RDKit fingerprinting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External string inputs (SMILES) passed to RDKit's parser and tensor peak arrays passed to the Spec2Graph Transformer did not have upper bounds, leading to potential Denial of Service (DoS) attacks via memory exhaustion. RDKit and O(N^2) Transformer mechanisms are vulnerable to extreme inputs.
 **Learning:** In machine learning processing pipelines, memory-intensive modules (like molecular parsing and self-attention) must implement hard size limits on inputs before computation, even if downstream layers process it.
 **Prevention:** Always implement an initial size check (e.g., `len(smiles) <= MAX_LEN` or `mz.shape[1] <= max_peaks`) at the very edge of the API or forward pass method to drop excessively large payloads immediately.
+
+## 2024-05-18 - RDKit Silent Acceptance of Empty SMILES
+**Vulnerability:** Empty strings `""` passed to `Chem.MolFromSmiles()` are parsed as valid `Mol` objects but possess exactly 0 atoms, which bypassing `mol is None` checks and causes downstream errors or unhandled behaviors during representation generation (like fingerprints).
+**Learning:** Checking if an RDKit object `is None` is insufficient to validate external SMILES input, as technically 0-atom valid objects can be constructed.
+**Prevention:** Always validate `mol.GetNumAtoms() > 0` immediately after instantiating an RDKit `Mol` from an untrusted source, even if parsing succeeded without error.

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -230,6 +230,12 @@ class SpectralDataProcessor:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
+
+        num_atoms = mol.GetNumAtoms()
+        if num_atoms == 0:
+            raise ValueError(
+                f"SMILES {smiles} resulted in 0 atoms after adding Hs."
+            )
         fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
         arr = np.zeros((n_bits,), dtype=np.float32)
         DataStructs.ConvertToNumpyArray(fp, arr)

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -941,6 +941,11 @@ def test_projection_matrix_raises_when_k_exceeds_eigenvectors():
 
 
 class TestSpectralDataProcessor:
+    def test_smiles_to_fingerprint_zero_atoms(self):
+        processor = SpectralDataProcessor()
+        with pytest.raises(ValueError, match="resulted in 0 atoms after adding Hs"):
+            processor.smiles_to_fingerprint("")
+
     def test_smiles_to_fingerprint_valid(self):
         """Valid SMILES should return a binary numpy array of expected length."""
         processor = SpectralDataProcessor()


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Empty strings `""` passed to `Chem.MolFromSmiles()` are parsed as valid `Mol` objects but possess exactly 0 atoms, which bypasses `mol is None` checks and causes downstream errors or unhandled behaviors during representation generation (like fingerprints).
🎯 **Impact:** Potential Denial of Service (DoS) or unexpected unhandled errors downstream in the pipeline when attempting to compute structures for 0-atom inputs.
🔧 **Fix:** Added a check `mol.GetNumAtoms() == 0` immediately after instantiating an RDKit `Mol` from an untrusted source, raising a `ValueError`.
✅ **Verification:** Ran test suite with the newly added test `test_smiles_to_fingerprint_zero_atoms` ensuring `ValueError` is correctly raised for an empty SMILES string.

---
*PR created automatically by Jules for task [14042182192108775693](https://jules.google.com/task/14042182192108775693) started by @CodeHalwell*