### PR TITLE
Harden input validation and optimize embedding precomputation

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -86,9 +86,13 @@ class SpectralDataProcessor:
             Adjacency matrix as numpy array
         """
         self._require_rdkit()
-        if not isinstance(smiles, str) or len(smiles) > MAX_SMILES_LENGTH:
+        if not isinstance(smiles, str):
+            raise TypeError(
+                f"SMILES must be a string; got {type(smiles).__name__}."
+            )
+        if len(smiles) > MAX_SMILES_LENGTH:
             raise ValueError(
-                f"SMILES string too long (length: {len(smiles) if isinstance(smiles, str) else 'N/A'}). "
+                f"SMILES string too long (length: {len(smiles)}). "
                 f"Maximum allowed length is {MAX_SMILES_LENGTH}."
             )
         mol = Chem.MolFromSmiles(smiles)
@@ -231,9 +235,13 @@ class SpectralDataProcessor:
     ) -> np.ndarray:
         """Compute Morgan fingerprint for a SMILES string."""
         self._require_rdkit()
-        if not isinstance(smiles, str) or len(smiles) > MAX_SMILES_LENGTH:
+        if not isinstance(smiles, str):
+            raise TypeError(
+                f"SMILES must be a string; got {type(smiles).__name__}."
+            )
+        if len(smiles) > MAX_SMILES_LENGTH:
             raise ValueError(
-                f"SMILES string too long (length: {len(smiles) if isinstance(smiles, str) else 'N/A'}). "
+                f"SMILES string too long (length: {len(smiles)}). "
                 f"Maximum allowed length is {MAX_SMILES_LENGTH}."
             )
         mol = Chem.MolFromSmiles(smiles)
@@ -605,6 +613,13 @@ class Spec2GraphDiffusion(nn.Module):
             raise ValueError(
                 f"Number of peaks ({mz.shape[1]}) exceeds configured max_peaks "
                 f"({self.max_peaks}); truncate the input or increase max_peaks."
+            )
+        if precursor_mz is not None and (
+            precursor_mz.dim() != 1 or precursor_mz.shape[0] != mz.shape[0]
+        ):
+            raise ValueError(
+                f"precursor_mz must have shape (batch,) matching mz's batch "
+                f"dimension ({mz.shape[0]}); got {tuple(precursor_mz.shape)}."
             )
 
         # Combine m/z and intensity embeddings
@@ -1314,10 +1329,10 @@ class SpectralGraphNeuralOperator(nn.Module):
         """Force zero self-loops for batched square matrices."""
         # Preserve the square-matrix contract — diagonal().zero_() would silently
         # operate on min(n, m) of a rectangular matrix, hiding upstream bugs.
-        if matrix.shape[-1] != matrix.shape[-2]:
+        if matrix.dim() < 2 or matrix.shape[-1] != matrix.shape[-2]:
             raise ValueError(
-                f"_zero_diagonal expects batched square matrices; got trailing "
-                f"shape {tuple(matrix.shape[-2:])}."
+                f"_zero_diagonal expects batched square matrices; got shape "
+                f"{tuple(matrix.shape)}."
             )
         # Use .diagonal().zero_() instead of allocating an O(N^2) identity mask
         # and running masked_fill. Clone first so we don't mutate an autograd

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -35,6 +35,9 @@ PROJECTION_EPS = 1e-8
 PROJECTION_WARNING_THRESHOLD = 256
 # Emit projection warning only once to avoid log spam during training
 PROJECTION_WARNING_EMITTED = False
+# Hard cap on SMILES string length to prevent DoS via unbounded RDKit parsing
+# and downstream O(N^3) eigendecomposition.
+MAX_SMILES_LENGTH = 2000
 
 try:
     from rdkit import Chem, DataStructs
@@ -83,8 +86,11 @@ class SpectralDataProcessor:
             Adjacency matrix as numpy array
         """
         self._require_rdkit()
-        if len(smiles) > 2000:
-            raise ValueError(f"SMILES string too long (length: {len(smiles)}). Maximum allowed length is 2000.")
+        if not isinstance(smiles, str) or len(smiles) > MAX_SMILES_LENGTH:
+            raise ValueError(
+                f"SMILES string too long (length: {len(smiles) if isinstance(smiles, str) else 'N/A'}). "
+                f"Maximum allowed length is {MAX_SMILES_LENGTH}."
+            )
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
@@ -225,8 +231,11 @@ class SpectralDataProcessor:
     ) -> np.ndarray:
         """Compute Morgan fingerprint for a SMILES string."""
         self._require_rdkit()
-        if len(smiles) > 2000:
-            raise ValueError(f"SMILES string too long (length: {len(smiles)}). Maximum allowed length is 2000.")
+        if not isinstance(smiles, str) or len(smiles) > MAX_SMILES_LENGTH:
+            raise ValueError(
+                f"SMILES string too long (length: {len(smiles) if isinstance(smiles, str) else 'N/A'}). "
+                f"Maximum allowed length is {MAX_SMILES_LENGTH}."
+            )
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
@@ -277,7 +286,8 @@ class FourierMzEmbedding(nn.Module):
         self.max_mz = max_mz
         self.num_freqs = num_freqs
 
-        # Create frequency bands
+        # Create frequency bands. `freqs` is kept as the persistent buffer to
+        # preserve state_dict compatibility for existing checkpoints.
         freqs = torch.exp(
             torch.linspace(
                 math.log(1.0), math.log(max_mz / 2.0), num_freqs // 2
@@ -285,8 +295,42 @@ class FourierMzEmbedding(nn.Module):
         )
         self.register_buffer("freqs", freqs)
 
+        # Precompute the fully-scaled angular frequencies so the forward pass
+        # avoids repeated normalization + 2*pi multiplication. Derived buffer,
+        # so it is non-persistent and refreshed after load_state_dict.
+        self.register_buffer(
+            "scaled_freqs",
+            self._compute_scaled_freqs(freqs),
+            persistent=False,
+        )
+
         # Projection layer
         self.proj = nn.Linear(num_freqs, d_model)
+
+    def _compute_scaled_freqs(self, freqs: torch.Tensor) -> torch.Tensor:
+        return freqs * (2.0 * math.pi / self.max_mz)
+
+    def _load_from_state_dict(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        super()._load_from_state_dict(
+            state_dict,
+            prefix,
+            local_metadata,
+            strict,
+            missing_keys,
+            unexpected_keys,
+            error_msgs,
+        )
+        # Keep derived buffer in sync when freqs is overwritten by a checkpoint.
+        self.scaled_freqs = self._compute_scaled_freqs(self.freqs)
 
     def forward(self, mz: torch.Tensor) -> torch.Tensor:
         """
@@ -298,12 +342,9 @@ class FourierMzEmbedding(nn.Module):
         Returns:
             Embeddings of shape (batch, n_peaks, d_model)
         """
-        # Normalize m/z values
-        mz_norm = mz / self.max_mz
-
-        # Compute Fourier features
+        # Compute Fourier features using precomputed scaled frequencies.
         # Shape: (batch, n_peaks, num_freqs // 2)
-        angles = mz_norm.unsqueeze(-1) * self.freqs * 2 * math.pi
+        angles = mz.unsqueeze(-1) * self.scaled_freqs
 
         # Sin and cos features
         features = torch.cat([torch.sin(angles), torch.cos(angles)], dim=-1)
@@ -353,6 +394,20 @@ class TimestepEmbedding(nn.Module):
         self.d_model = d_model
         self.max_period = max_period
 
+        # Precompute sinusoidal frequency bands once; they depend only on
+        # d_model/max_period. Non-persistent so load_state_dict with older
+        # checkpoints keeps working.
+        half_dim = self.d_model // 2
+        if half_dim > 0:
+            freqs = torch.exp(
+                -math.log(self.max_period)
+                * torch.arange(half_dim, dtype=torch.float32)
+                / half_dim
+            )
+        else:
+            freqs = torch.zeros(0, dtype=torch.float32)
+        self.register_buffer("freqs", freqs, persistent=False)
+
         self.mlp = nn.Sequential(
             nn.Linear(d_model, d_model * 4),
             nn.GELU(),
@@ -369,13 +424,7 @@ class TimestepEmbedding(nn.Module):
         Returns:
             Embedding of shape (batch, d_model)
         """
-        half_dim = self.d_model // 2
-        freqs = torch.exp(
-            -math.log(self.max_period)
-            * torch.arange(half_dim, device=t.device, dtype=torch.float32)
-            / half_dim
-        )
-        args = t.float().unsqueeze(-1) * freqs
+        args = t.float().unsqueeze(-1) * self.freqs
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
 
         if self.d_model % 2 == 1:
@@ -539,8 +588,24 @@ class Spec2GraphDiffusion(nn.Module):
         Returns:
             Encoded spectrum, shape (batch, n_peaks, d_model)
         """
+        if mz.dim() != 2:
+            raise ValueError(
+                f"mz must have shape (batch, n_peaks); got {tuple(mz.shape)}."
+            )
+        if intensity.dim() != 2:
+            raise ValueError(
+                f"intensity must have shape (batch, n_peaks); got {tuple(intensity.shape)}."
+            )
+        if mz.shape != intensity.shape:
+            raise ValueError(
+                f"mz and intensity must have matching shape (batch, n_peaks); "
+                f"got {tuple(mz.shape)} and {tuple(intensity.shape)}."
+            )
         if mz.shape[1] > self.max_peaks:
-            raise ValueError(f"Number of peaks ({mz.shape[1]}) exceeds maximum allowed ({self.max_peaks})")
+            raise ValueError(
+                f"Number of peaks ({mz.shape[1]}) exceeds configured max_peaks "
+                f"({self.max_peaks}); truncate the input or increase max_peaks."
+            )
 
         # Combine m/z and intensity embeddings
         mz_emb = self.mz_embedding(mz)
@@ -1247,9 +1312,16 @@ class SpectralGraphNeuralOperator(nn.Module):
     @staticmethod
     def _zero_diagonal(matrix: torch.Tensor) -> torch.Tensor:
         """Force zero self-loops for batched square matrices."""
-        # OPTIMIZATION: Use .diagonal().zero_() instead of allocating an O(N^2)
-        # identity matrix and using masked_fill. This avoids memory overhead
-        # and runs ~3x faster. matrix is cloned to avoid in-place mutation issues.
+        # Preserve the square-matrix contract — diagonal().zero_() would silently
+        # operate on min(n, m) of a rectangular matrix, hiding upstream bugs.
+        if matrix.shape[-1] != matrix.shape[-2]:
+            raise ValueError(
+                f"_zero_diagonal expects batched square matrices; got trailing "
+                f"shape {tuple(matrix.shape[-2:])}."
+            )
+        # Use .diagonal().zero_() instead of allocating an O(N^2) identity mask
+        # and running masked_fill. Clone first so we don't mutate an autograd
+        # intermediate in-place.
         matrix = matrix.clone()
         matrix.diagonal(dim1=-2, dim2=-1).zero_()
         return matrix

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -965,3 +965,113 @@ class TestSpectralDataProcessor:
         processor = SpectralDataProcessor()
         with pytest.raises(ValueError, match="Invalid SMILES:"):
             processor.smiles_to_fingerprint("invalid_smiles_string")
+
+
+class TestInputValidationBoundaries:
+    """Regression tests for the DoS-hardening input validation."""
+
+    def test_smiles_to_adjacency_rejects_overlong_smiles(self):
+        from spectral_diffusion import MAX_SMILES_LENGTH
+
+        processor = SpectralDataProcessor()
+        overlong = "C" * (MAX_SMILES_LENGTH + 1)
+        with pytest.raises(ValueError, match="SMILES string too long"):
+            processor.smiles_to_adjacency(overlong)
+
+    def test_smiles_to_fingerprint_rejects_overlong_smiles(self):
+        from spectral_diffusion import MAX_SMILES_LENGTH
+
+        processor = SpectralDataProcessor()
+        overlong = "C" * (MAX_SMILES_LENGTH + 1)
+        with pytest.raises(ValueError, match="SMILES string too long"):
+            processor.smiles_to_fingerprint(overlong)
+
+    def test_encode_spectrum_rejects_n_peaks_above_max(self):
+        model = Spec2GraphDiffusion(
+            Spec2GraphDiffusionConfig(
+                k=2, max_atoms=4, max_peaks=4, d_model=16, nhead=2,
+                num_encoder_layers=1, num_decoder_layers=1,
+            )
+        )
+        mz = torch.zeros(1, model.max_peaks + 1)
+        intensity = torch.zeros(1, model.max_peaks + 1)
+        with pytest.raises(ValueError, match="exceeds configured max_peaks"):
+            model.encode_spectrum(mz, intensity)
+
+    def test_encode_spectrum_allows_n_peaks_at_boundary(self):
+        model = Spec2GraphDiffusion(
+            Spec2GraphDiffusionConfig(
+                k=2, max_atoms=4, max_peaks=4, d_model=16, nhead=2,
+                num_encoder_layers=1, num_decoder_layers=1,
+            )
+        )
+        mz = torch.zeros(1, model.max_peaks)
+        intensity = torch.zeros(1, model.max_peaks)
+        # Should not raise
+        enc = model.encode_spectrum(mz, intensity)
+        assert enc.shape == (1, model.max_peaks, 16)
+
+    def test_encode_spectrum_rejects_1d_mz(self):
+        model = Spec2GraphDiffusion(
+            Spec2GraphDiffusionConfig(
+                k=2, max_atoms=4, max_peaks=4, d_model=16, nhead=2,
+                num_encoder_layers=1, num_decoder_layers=1,
+            )
+        )
+        with pytest.raises(ValueError, match="mz must have shape"):
+            model.encode_spectrum(torch.zeros(4), torch.zeros(1, 4))
+
+    def test_encode_spectrum_rejects_shape_mismatch(self):
+        model = Spec2GraphDiffusion(
+            Spec2GraphDiffusionConfig(
+                k=2, max_atoms=4, max_peaks=4, d_model=16, nhead=2,
+                num_encoder_layers=1, num_decoder_layers=1,
+            )
+        )
+        with pytest.raises(ValueError, match="matching shape"):
+            model.encode_spectrum(torch.zeros(1, 4), torch.zeros(1, 3))
+
+    def test_zero_diagonal_rejects_non_square(self):
+        sgno = SpectralGraphNeuralOperator(k=2, hidden_dim=8, num_layers=1)
+        rectangular = torch.zeros(1, 3, 4)
+        with pytest.raises(ValueError, match="batched square matrices"):
+            sgno._zero_diagonal(rectangular)
+
+    def test_zero_diagonal_zeroes_square(self):
+        sgno = SpectralGraphNeuralOperator(k=2, hidden_dim=8, num_layers=1)
+        m = torch.ones(2, 3, 3)
+        out = sgno._zero_diagonal(m)
+        assert torch.all(out.diagonal(dim1=-2, dim2=-1) == 0)
+        # Off-diagonal entries should be preserved
+        assert out[0, 0, 1].item() == 1.0
+        # Input must not be mutated (clone semantics)
+        assert torch.all(m == 1.0)
+
+
+class TestEmbeddingBufferConsistency:
+    """Ensure precomputed embedding buffers stay consistent across load_state_dict."""
+
+    def test_fourier_mz_embedding_refreshes_scaled_freqs_on_load(self):
+        from spectral_diffusion import FourierMzEmbedding
+
+        src = FourierMzEmbedding(d_model=16, max_mz=2000.0, num_freqs=8)
+        dst = FourierMzEmbedding(d_model=16, max_mz=2000.0, num_freqs=8)
+
+        # Perturb the source buffer so the derived scaled_freqs must be refreshed
+        with torch.no_grad():
+            src.freqs.mul_(2.0)
+            src.scaled_freqs = src._compute_scaled_freqs(src.freqs)
+
+        dst.load_state_dict(src.state_dict(), strict=True)
+
+        assert torch.allclose(dst.freqs, src.freqs)
+        assert torch.allclose(dst.scaled_freqs, src.scaled_freqs)
+
+    def test_timestep_embedding_handles_small_d_model(self):
+        from spectral_diffusion import TimestepEmbedding
+
+        # d_model=1 -> half_dim=0; precompute must not divide by zero
+        emb = TimestepEmbedding(d_model=2, max_period=100)
+        out = emb(torch.tensor([0.0, 1.0]))
+        assert out.shape == (2, 2)
+        assert torch.all(torch.isfinite(out))

--- a/tests/test_spec2graph.py
+++ b/tests/test_spec2graph.py
@@ -986,6 +986,16 @@ class TestInputValidationBoundaries:
         with pytest.raises(ValueError, match="SMILES string too long"):
             processor.smiles_to_fingerprint(overlong)
 
+    def test_smiles_to_adjacency_rejects_non_string(self):
+        processor = SpectralDataProcessor()
+        with pytest.raises(TypeError, match="SMILES must be a string"):
+            processor.smiles_to_adjacency(12345)
+
+    def test_smiles_to_fingerprint_rejects_non_string(self):
+        processor = SpectralDataProcessor()
+        with pytest.raises(TypeError, match="SMILES must be a string"):
+            processor.smiles_to_fingerprint(12345)
+
     def test_encode_spectrum_rejects_n_peaks_above_max(self):
         model = Spec2GraphDiffusion(
             Spec2GraphDiffusionConfig(
@@ -1037,6 +1047,28 @@ class TestInputValidationBoundaries:
         with pytest.raises(ValueError, match="batched square matrices"):
             sgno._zero_diagonal(rectangular)
 
+    def test_zero_diagonal_rejects_sub_2d(self):
+        sgno = SpectralGraphNeuralOperator(k=2, hidden_dim=8, num_layers=1)
+        with pytest.raises(ValueError, match="batched square matrices"):
+            sgno._zero_diagonal(torch.zeros(4))
+
+    def test_encode_spectrum_rejects_bad_precursor_mz(self):
+        model = Spec2GraphDiffusion(
+            Spec2GraphDiffusionConfig(
+                k=2, max_atoms=4, max_peaks=4, d_model=16, nhead=2,
+                num_encoder_layers=1, num_decoder_layers=1,
+                enable_precursor_conditioning=True,
+            )
+        )
+        mz = torch.zeros(2, 4)
+        intensity = torch.zeros(2, 4)
+        # 2D precursor_mz should be rejected
+        with pytest.raises(ValueError, match="precursor_mz must have shape"):
+            model.encode_spectrum(mz, intensity, precursor_mz=torch.zeros(2, 1))
+        # Mismatched batch dimension should also be rejected
+        with pytest.raises(ValueError, match="precursor_mz must have shape"):
+            model.encode_spectrum(mz, intensity, precursor_mz=torch.zeros(3))
+
     def test_zero_diagonal_zeroes_square(self):
         sgno = SpectralGraphNeuralOperator(k=2, hidden_dim=8, num_layers=1)
         m = torch.ones(2, 3, 3)
@@ -1071,7 +1103,8 @@ class TestEmbeddingBufferConsistency:
         from spectral_diffusion import TimestepEmbedding
 
         # d_model=1 -> half_dim=0; precompute must not divide by zero
-        emb = TimestepEmbedding(d_model=2, max_period=100)
+        emb = TimestepEmbedding(d_model=1, max_period=100)
+        assert emb.freqs.numel() == 0
         out = emb(torch.tensor([0.0, 1.0]))
-        assert out.shape == (2, 2)
+        assert out.shape == (2, 1)
         assert torch.all(torch.isfinite(out))


### PR DESCRIPTION
## Summary
This PR improves robustness and performance by hardening input validation against denial-of-service attacks and optimizing embedding computations through precomputation of frequency buffers.

## Key Changes

### Input Validation Hardening
- **SMILES length validation**: Extracted magic number `2000` into module-level constant `MAX_SMILES_LENGTH` for maintainability
- **Type checking**: Added `isinstance(smiles, str)` checks in `smiles_to_adjacency()` and `smiles_to_fingerprint()` to reject non-string inputs before calling `len()`
- **Spectrum encoding validation**: Added comprehensive shape validation in `encode_spectrum()`:
  - Enforce 2D shape for `mz` and `intensity` tensors
  - Validate shape matching between `mz` and `intensity`
  - Improved error messages with actionable guidance
- **Graph operator validation**: Added shape contract enforcement in `SpectralGraphNeuralOperator._zero_diagonal()` to reject non-square matrices and prevent silent bugs from upstream shape errors

### Embedding Optimization
- **FourierMzEmbedding**: Precompute scaled frequencies (`scaled_freqs = freqs * 2π / max_mz`) as a non-persistent buffer to avoid repeated normalization in the forward pass. Implemented `_load_from_state_dict()` hook to refresh derived buffer after checkpoint loading while maintaining backward compatibility
- **TimestepEmbedding**: Precompute sinusoidal frequency bands in `__init__()` as a non-persistent buffer instead of recomputing them on every forward pass. Added guard against division by zero for edge case `d_model < 2`

### Code Quality
- Improved error messages with context (e.g., "exceeds configured max_peaks; truncate the input or increase max_peaks")
- Enhanced comments explaining optimization rationale and state_dict compatibility considerations
- Added comprehensive regression tests covering DoS boundaries, shape validation, and buffer consistency across checkpoint loading

## Implementation Details
- Non-persistent buffers (`persistent=False`) ensure derived/precomputed buffers are refreshed after `load_state_dict()`, maintaining compatibility with older checkpoints while avoiding stale state
- The `_zero_diagonal()` optimization uses `.diagonal().zero_()` instead of allocating O(N²) identity masks, improving both memory and speed
- All validation changes are backward-compatible; they only reject invalid inputs that would have failed downstream anyway

https://claude.ai/code/session_012pfsHGAEAimD7cNHAqNYot