### PR TITLE
Add comprehensive documentation for Spec2Graph pipeline

### DIFF
--- a/docs/01_pipeline_overview.md
+++ b/docs/01_pipeline_overview.md
@@ -1,0 +1,100 @@
+# 01 — Pipeline Overview
+
+Spec2Graph learns a map from a mass spectrum to a molecular graph. It does
+this in two conceptual halves:
+
+1. **Spectrum → eigenvectors.** A diffusion model takes mass-spec peaks and
+   generates the top-`k` eigenvectors of the target molecule's Laplacian.
+2. **Eigenvectors → graph.** A decoder turns those eigenvectors into a bond
+   matrix (optionally constrained by chemistry rules) to produce a predicted
+   molecule.
+
+This document sketches the whole path at a high level. Each later doc zooms
+into one stage.
+
+## Inputs and outputs
+
+| Stage | Input | Output |
+|-------|-------|--------|
+| Data processing | SMILES string | `V_k` eigenvectors `(N, k)` |
+| Spectrum encoding | `(mz, intensity)` peak lists | Encoded memory `(B, n_peaks, d_model)` |
+| Forward diffusion | `x_0 = V_k` + timestep `t` | Noisy `x_t` + the noise `ε` |
+| Model forward | `x_t`, `t`, spectrum | Predicted noise `ε̂` |
+| Loss | `ε̂`, `ε`, `x_0` | Scalar loss for backprop |
+| Sampling | Random noise + spectrum | Generated `V̂_k` |
+| Decode | `V̂_k` | Adjacency matrix / graph |
+
+## The training path in one diagram
+
+```text
+                              ┌──────────────────────────────────┐
+ SMILES ──► RDKit mol ──► adjacency ──► Laplacian ──► eigvecs V_k │ data processing
+                              └──────────────────┬───────────────┘
+                                                 │ (N, k)
+                                                 ▼
+ (mz, intensity) ──► Fourier + linear ──► TransformerEncoder ──► memory (B, n_peaks, d_model)
+                                                 │                              │
+                                                 ▼                              │
+ t ~ Uniform{0,T-1}   ε ~ 𝒩(0, I)                                               │
+              │             │                                                   │
+              ▼             ▼                                                   │
+              x_t = √ᾱ_t·x_0 + √(1−ᾱ_t)·ε                                      │
+                             │                                                  │
+                             ▼                                                  │
+ atom_pos + time_emb ──► TransformerDecoder ◄── cross-attend to memory ─────────┘
+                             │
+                             ▼
+                       ε̂ (B, N, k)
+                             │
+                             ▼
+        ┌────────────────────┴──────────────────────┐
+        │   noise MSE                                │ primary loss
+        │   projection loss ‖P̂_k − P_k‖²_F          │ subspace-invariant
+        │   orthonormality ‖V̂ᵀV̂ − I‖²_F             │ keeps outputs orthonormal
+        │   (optional) fingerprint / atom-count /   │ aux heads on spectrum
+        │   eigenvalue heads                         │
+        └──────────────────────┬────────────────────┘
+                               ▼
+                           loss.backward()
+                           optimizer.step()
+```
+
+At inference, the diffusion runs in reverse — start from pure noise, denoise
+for `T` steps using the spectrum as conditioning, then feed the resulting
+eigenvectors into a decoder to obtain bonds.
+
+## Where everything lives
+
+Every class below is defined in
+[`spectral_diffusion.py`](../spectral_diffusion.py). The rest of this doc set
+references line numbers in that file.
+
+| Component | Class | Role |
+|-----------|-------|------|
+| Data processing | `SpectralDataProcessor` (L54) | SMILES → eigenvectors / projection |
+| m/z embedding | `FourierMzEmbedding` (L280) | Sinusoidal features for peak positions |
+| Intensity embedding | `IntensityEmbedding` (L364) | Linear embedding of intensities |
+| Timestep embedding | `TimestepEmbedding` (L390) | Sinusoidal + MLP for diffusion step `t` |
+| Core model | `Spec2GraphDiffusion` (L464) | Transformer encoder/decoder + heads |
+| Trainer | `DiffusionTrainer` (L825) | DDPM schedule, losses, sampling |
+| Graph decoder | `SpectralGraphNeuralOperator` (L1297) | Eigenvectors → adjacency logits |
+| Validity scorer | `DenseGNNDiscriminator` (L1456) | Scores chemical plausibility |
+| Guided sampler | `GuidedDiffusionSampler` (L1517) | Steers diffusion with discriminator |
+| Valency decoding | `ValencyDecoder` (L1673) | Greedy, valency-constrained adjacency |
+| Eigenvalue head | `EigenvalueConditioner` (L1783) | Optional eigenvalue conditioning |
+
+## The one non-obvious design choice
+
+Laplacian eigenvectors are **ambiguous**: a sign flip or a rotation inside a
+degenerate eigenspace yields a different `V_k` for the same graph. Regressing
+onto raw `V_k` is therefore ill-posed. Spec2Graph sidesteps this by training
+an extra loss on the **projection matrix** `P_k = V_k V_k^T`, which is
+invariant under those transformations. See
+[`07_training_losses.md`](./07_training_losses.md) for the full treatment.
+
+## Reading path suggestions
+
+- "I want to understand training." Read 02 → 05 → 06 → 07 → 08.
+- "I want to understand inference." Read 02 → 06 → 09 → 10.
+- "I want to add a new auxiliary loss." Read 06 → 07 → 08.
+- "I want to swap the decoder." Read 02 → 10 → 11.

--- a/docs/01_pipeline_overview.md
+++ b/docs/01_pipeline_overview.md
@@ -18,7 +18,7 @@ into one stage.
 |-------|-------|--------|
 | Data processing | SMILES string | `V_k` eigenvectors `(N, k)` |
 | Spectrum encoding | `(mz, intensity)` peak lists | Encoded memory `(B, n_peaks, d_model)` |
-| Forward diffusion | `x_0 = V_k` + timestep `t` | Noisy `x_t` + the noise `ε` |
+| Forward diffusion | `x_0 = V_k`, timestep `t` | Noisy `x_t`, noise `ε` |
 | Model forward | `x_t`, `t`, spectrum | Predicted noise `ε̂` |
 | Loss | `ε̂`, `ε`, `x_0` | Scalar loss for backprop |
 | Sampling | Random noise + spectrum | Generated `V̂_k` |
@@ -88,7 +88,7 @@ references line numbers in that file.
 Laplacian eigenvectors are **ambiguous**: a sign flip or a rotation inside a
 degenerate eigenspace yields a different `V_k` for the same graph. Regressing
 onto raw `V_k` is therefore ill-posed. Spec2Graph sidesteps this by training
-an extra loss on the **projection matrix** `P_k = V_k V_k^T`, which is
+an extra loss on the **projection matrix** `P_k = V_k V_kᵀ`, which is
 invariant under those transformations. See
 [`07_training_losses.md`](./07_training_losses.md) for the full treatment.
 

--- a/docs/02_data_processing.md
+++ b/docs/02_data_processing.md
@@ -1,0 +1,177 @@
+# 02 — Data Processing: SMILES to Eigenvectors
+
+Before any ML runs, we need a numerical target. Spec2Graph's target is the
+top-`k` eigenvectors of a molecule's normalized Laplacian. This doc walks
+through the four functions of `SpectralDataProcessor`
+(`spectral_diffusion.py:54`) that turn a SMILES string into that target.
+
+The pipeline is:
+
+```text
+SMILES  ──►  adjacency  ──►  Laplacian  ──►  eigenvectors V_k  (──► P_k = V_k V_kᵀ)
+```
+
+## Step 1 — SMILES → adjacency matrix
+
+`smiles_to_adjacency` (`spectral_diffusion.py:78`) parses the SMILES with
+RDKit and writes one row/column per atom. Bond weights come from one of
+three modes chosen at construction time:
+
+- `"unweighted"` — every bond has weight 1.
+- `"order"` (default) — `single=1, double=2, triple=3, aromatic=1.5`.
+- `"aromatic"` — aromatic bonds get 1.5, everything else 1.
+
+Input checks you should be aware of:
+
+- SMILES must be a `str`.
+- Length is capped at `MAX_SMILES_LENGTH = 2000` (L40). This prevents DoS
+  from pathological inputs that would blow up the downstream `O(N³)`
+  eigendecomposition.
+- Invalid SMILES raises `ValueError`.
+- A molecule with zero atoms also raises — we never want to build a 0×0
+  Laplacian silently.
+
+The returned matrix is symmetric `float32` of shape `(N, N)` where `N` is the
+number of heavy atoms.
+
+## Step 2 — adjacency → normalized Laplacian
+
+`compute_laplacian` (`spectral_diffusion.py:128`) builds:
+
+```
+L = I − D^{−1/2} · A · D^{−1/2}
+```
+
+with `D` the diagonal degree matrix. The implementation is defensive about
+isolated atoms:
+
+```python
+eps = 1e-12
+degree_inv_sqrt = np.where(degree > eps, 1.0 / np.sqrt(degree), 0.0)
+```
+
+So atoms with zero degree contribute `0` rather than a NaN. That keeps the
+Laplacian well-defined even when you pass in disconnected fragments.
+
+The normalized form is convenient for two reasons:
+
+1. Eigenvalues are bounded in `[0, 2]`, which keeps training numerically
+   stable.
+2. Eigenvectors of the normalized Laplacian are a smooth "coordinate system"
+   on the graph — closeness in eigenvector space correlates with being
+   neighbors, which is exactly what the SGNO decoder will exploit later
+   (see [10 — Prediction decoders](./10_prediction_decoders.md)).
+
+## Step 3 — Laplacian → top-`k` eigenvectors
+
+`extract_eigenvectors` (`spectral_diffusion.py:150`) calls
+`np.linalg.eigh` (dense symmetric eigendecomposition) and then does three
+things that matter:
+
+### 3a. Sort ascending and skip the zero eigenvalue
+
+For a connected graph the smallest eigenvalue of the normalized Laplacian is
+exactly 0, with the constant eigenvector. That carries no structural
+information, so we skip over it:
+
+```python
+start_idx = int((eigenvalues < eps).sum())
+```
+
+For disconnected graphs, the multiplicity of 0 equals the number of connected
+components, and we skip all of them.
+
+### 3b. Select `k` vectors (pad with zeros if fewer exist)
+
+If the molecule has fewer non-trivial eigenvectors than `k`, the output is
+right-padded with zero columns so downstream shapes are always `(N, k)`.
+
+### 3c. Sign canonicalization
+
+Eigenvectors are only defined up to a sign: `−v` is just as valid as `v`.
+That breaks any regression target. To make the target **deterministic** for a
+given graph, the code flips each eigenvector so its first non-negligible
+entry is positive:
+
+```python
+mask = np.abs(selected) > 1e-10
+has_nonzero = mask.any(axis=0)
+idx = mask.argmax(axis=0)          # index of first |entry| > 1e-10
+zero_cols = ~has_nonzero
+if zero_cols.any():                # fallback for ~zero vectors
+    idx[zero_cols] = np.abs(selected[:, zero_cols]).argmax(axis=0)
+first_vals = selected[idx, col_idx]
+signs = np.where(first_vals < 0, -1, 1)
+selected *= signs
+```
+
+This helps training, but it **doesn't solve the rotation ambiguity** when
+eigenvalues are degenerate. That's the job of the projection loss below.
+
+## Step 4 (optional) — projection matrix `P_k`
+
+`projection_matrix` (`spectral_diffusion.py:205`) computes:
+
+```
+P_k = V_k · V_kᵀ                      ∈ ℝ^{N×N}
+```
+
+`P_k` is the orthogonal projector onto the span of `V_k`. Two key properties:
+
+- **Sign-invariant.** Flip any column of `V_k`: `V_kᵀ` flips the same column,
+  so the product `V_k V_kᵀ` is unchanged.
+- **Rotation-invariant within an eigenspace.** For any orthogonal `Q`
+  mixing columns inside a degenerate eigenspace,
+  `(V_k Q)(V_k Q)ᵀ = V_k Q Qᵀ V_kᵀ = V_k V_kᵀ`.
+
+So `P_k` is a *subspace-invariant* target: two equivalent decompositions of
+the same graph produce the same `P_k`. That makes it a much better regression
+target than raw eigenvectors. The diffusion model itself still predicts
+eigenvectors (for computational reasons), but the loss includes a penalty
+on `P̂_k − P_k` — see [07 — Training losses](./07_training_losses.md).
+
+## Step 5 (optional) — Morgan fingerprint
+
+`smiles_to_fingerprint` (`spectral_diffusion.py:233`) builds a Morgan
+(circular) fingerprint of the molecule (default 2048 bits, radius 2) as a
+binary vector. It's used when you enable the auxiliary fingerprint head —
+see [07 — Training losses](./07_training_losses.md).
+
+## Putting it together: `process_smiles`
+
+The convenience method `process_smiles` (`spectral_diffusion.py:255`) glues
+the three mandatory steps together:
+
+```python
+processor = SpectralDataProcessor(k=8)
+eigvecs = processor.process_smiles("c1ccccc1")             # (6, 8)
+eigvecs, proj = processor.process_smiles("c1ccccc1", return_projection=True)
+# proj.shape == (6, 6)
+```
+
+## Common gotchas
+
+- **Variable atom counts.** Different molecules have different `N`. The
+  demo pads them per-batch (see [04 — Batching and masks](./04_batching_and_masks.md)).
+- **`k` larger than available eigenvectors.** `extract_eigenvectors` silently
+  zero-pads. `projection_matrix` separately checks `k <= n_vectors` — if you
+  call it with an already-padded matrix, be mindful that the trailing zero
+  columns contribute nothing to `P_k`.
+- **RDKit required.** `process_smiles` raises a clear `ImportError` at call
+  time if RDKit is missing. Every model in the repo that doesn't need SMILES
+  input will still import successfully without it.
+- **Cost.** `eigh` is `O(N³)`. That's fine for drug-like molecules but
+  explodes for peptides and polymers; `MAX_SMILES_LENGTH` caps the worst
+  case.
+
+## What this produces for the rest of the pipeline
+
+After this stage, every training example is represented by:
+
+- `V_k ∈ ℝ^{N × k}` — the clean target the diffusion model learns to denoise.
+- Optionally `P_k ∈ ℝ^{N × N}` — used only by the projection loss; the
+  trainer recomputes it from `V_k` at training time, so you don't usually
+  need to store it alongside the data.
+
+Next: [03 — Spectrum encoding](./03_spectrum_encoding.md) covers how the
+conditioning spectrum is prepared.

--- a/docs/03_spectrum_encoding.md
+++ b/docs/03_spectrum_encoding.md
@@ -1,0 +1,171 @@
+# 03 — Spectrum Encoding
+
+Each training example pairs eigenvectors (the target) with a mass spectrum
+(the conditioning). This doc covers how raw `(m/z, intensity)` peak lists
+become tensors the transformer can consume.
+
+Four embeddings are involved:
+
+1. `FourierMzEmbedding` — positional features for m/z.
+2. `IntensityEmbedding` — linear projection of peak intensities.
+3. `TimestepEmbedding` — for the diffusion step `t` (covered here because it
+   mirrors the Fourier idea).
+4. `atom_pos_embedding` — a learned `nn.Embedding` for atom indices
+   (defined inside `Spec2GraphDiffusion`).
+
+## FourierMzEmbedding
+
+Defined at `spectral_diffusion.py:280`.
+
+Mass-spec peaks live on a continuous axis (m/z ∈ roughly `[0, 2000]`). A
+naïve embedding would truncate to integers or slam them through a single
+`Linear` that has to learn everything. Fourier features instead project each
+m/z onto a bank of sinusoids at geometrically spaced frequencies, giving the
+transformer a smooth, scale-aware position code.
+
+### Frequency bank
+
+```python
+freqs = torch.exp(torch.linspace(
+    math.log(1.0), math.log(max_mz / 2.0), num_freqs // 2
+))
+```
+
+`num_freqs = 64` by default, so we get 32 frequency bands geometrically
+spread between 1.0 and `max_mz / 2 = 1000`. The lowest frequency captures
+peaks that differ by hundreds of Da; the highest resolves near-integer
+m/z differences.
+
+### Precomputed scaling
+
+```python
+self.register_buffer(
+    "scaled_freqs",
+    self._compute_scaled_freqs(freqs),     # freqs * 2π / max_mz
+    persistent=False,
+)
+```
+
+The buffer is non-persistent because it's derived from `freqs`. An override of
+`_load_from_state_dict` (`spectral_diffusion.py:321`) rebuilds it whenever a
+checkpoint is loaded, which keeps old checkpoints (saved before the precompute
+optimization) fully compatible.
+
+### Forward pass
+
+```python
+angles = mz.unsqueeze(-1) * self.scaled_freqs           # (B, n_peaks, 32)
+features = torch.cat([sin(angles), cos(angles)], dim=-1)  # (B, n_peaks, 64)
+return self.proj(features)                                # (B, n_peaks, d_model)
+```
+
+So each peak ends up with a `d_model`-dimensional embedding where the first
+layer has built-in sensitivity to mass scale.
+
+## IntensityEmbedding
+
+Defined at `spectral_diffusion.py:364`. Simpler: a single `Linear(1,
+d_model)` applied to `intensity.unsqueeze(-1)`. Intensities are typically
+normalized to `[0, 1]` or log-scaled beforehand; the module doesn't
+prescribe a scheme.
+
+## Combining them
+
+Inside `Spec2GraphDiffusion.encode_spectrum`
+(`spectral_diffusion.py:580`):
+
+```python
+mz_emb  = self.mz_embedding(mz)          # (B, n_peaks, d_model)
+int_emb = self.intensity_embedding(intensity)
+spectrum_emb = mz_emb + int_emb          # additive fusion
+```
+
+Additive fusion keeps parameter count low and works well as a first pass.
+If you later want multiplicative gating or concatenation followed by a
+projection, this is the natural hook point.
+
+The result is then passed to `self.spectrum_encoder` (a
+`nn.TransformerEncoder`) with a padding mask derived from `spectrum_mask`:
+
+```python
+src_key_padding_mask = ~mask    # PyTorch uses True=ignore
+encoded = self.spectrum_encoder(spectrum_emb, src_key_padding_mask=...)
+encoded = self.encoder_norm(encoded)
+```
+
+Note the inversion of the mask — throughout Spec2Graph, user-facing masks
+use `True = valid`. Only at the transformer boundary do we flip the
+convention to match PyTorch.
+
+## Optional: precursor conditioning
+
+If you enable `enable_precursor_conditioning=True` in
+`Spec2GraphDiffusionConfig`, the model additionally takes a single
+precursor m/z per batch item. The encode path then does:
+
+```python
+precursor_emb = self.precursor_embedding(precursor_mz.unsqueeze(-1))   # (B, 1, d_model)
+pooled = self._pool_spectrum(encoded, spectrum_mask)                   # (B, d_model)
+fused = self.precursor_fusion(torch.cat([pooled, precursor_emb.squeeze(1)], dim=-1))
+encoded = encoded + fused.unsqueeze(1)      # broadcast to all peak positions
+```
+
+Two things to notice:
+
+- `_pool_spectrum` does **mask-aware mean pooling**
+  (`spectral_diffusion.py:733`). It divides by the number of valid peaks, not
+  by the padded length.
+- The fused vector is **broadcast** back to every peak position. This gives
+  every peak token access to the precursor context without resizing the
+  sequence.
+
+## TimestepEmbedding
+
+Defined at `spectral_diffusion.py:390`. The diffusion model needs to know
+*which* noise level it's denoising. We give it a standard sinusoidal
+embedding followed by a small MLP:
+
+```python
+half_dim = d_model // 2
+freqs = torch.exp(-math.log(max_period) * torch.arange(half_dim) / half_dim)
+```
+
+The forward pass is:
+
+```python
+args = t.float().unsqueeze(-1) * self.freqs           # (B, half_dim)
+embedding = torch.cat([cos(args), sin(args)], dim=-1) # (B, 2*half_dim)
+return self.mlp(embedding)                            # (B, d_model)
+```
+
+This timestep embedding is later **added** to the decoder input tokens (same
+d_model) so every atom position is aware of the current noise level.
+
+## Atom position embedding
+
+Not in a separate class — it's `self.atom_pos_embedding = nn.Embedding(max_atoms, d_model)`
+inside `Spec2GraphDiffusion` (`spectral_diffusion.py:505`). Atoms don't have
+an inherent sequential position, but the transformer still needs a way to
+distinguish "atom 0" from "atom 1" as tokens. A learned positional embedding
+indexed by position does the job.
+
+This is one of the reasons the model is **not permutation-invariant** by
+design: the atom ordering is taken as given (typically the RDKit canonical
+ordering). That tradeoff is flagged as a risk in `ROADMAP.md`.
+
+## Summary of shapes
+
+At the end of spectrum encoding, inside the model forward pass:
+
+| Tensor | Shape |
+|--------|-------|
+| `mz` | `(B, n_peaks)` |
+| `intensity` | `(B, n_peaks)` |
+| `spectrum_mask` (optional) | `(B, n_peaks)` bool |
+| `precursor_mz` (optional) | `(B,)` |
+| `memory` after `encode_spectrum` | `(B, n_peaks, d_model)` |
+| `t` | `(B,)` long |
+| `t_emb` | `(B, d_model)` |
+
+Next: [04 — Batching and masks](./04_batching_and_masks.md) explains how
+variable-length examples are stitched together into a single batch.

--- a/docs/04_batching_and_masks.md
+++ b/docs/04_batching_and_masks.md
@@ -1,0 +1,146 @@
+# 04 — Batching and Masks
+
+Molecules have different atom counts. Spectra have different peak counts.
+To run in a single batched forward pass we pad each tensor to the batch
+maximum and use boolean masks to tell the model which positions are real.
+
+This doc covers the conventions, the validation checks, and the end-to-end
+construction of a padded batch.
+
+## Mask convention: **True = valid**
+
+Every user-facing mask in Spec2Graph uses `True = valid, False = padding`.
+This is enforced by `_validate_mask` (`spectral_diffusion.py:570`):
+
+```python
+if mask.dtype != torch.bool:
+    raise ValueError(f"{name} must be a boolean tensor with True indicating valid entries.")
+if mask.dim() != 2 or mask.shape[1] != expected_length:
+    raise ValueError(f"{name} must have shape (batch, length); got {mask.shape}.")
+if not mask.any(dim=1).all():
+    raise ValueError(f"{name} must contain at least one valid element per batch item.")
+```
+
+Those three checks catch the most common mistakes in practice:
+
+1. Passing a float/int mask instead of bool.
+2. Passing a mask with the wrong length.
+3. Accidentally creating an all-padding row (the model has nothing to attend
+   to and silently produces garbage).
+
+The mask is only inverted (`~mask`) right before being handed to PyTorch's
+transformer layers, which use `True = ignore`. Users never need to think
+about that flip.
+
+## The two masks you pass
+
+| Name | Shape | Meaning |
+|------|-------|---------|
+| `atom_mask` | `(B, n_atoms)` | Which eigenvector rows are real atoms. |
+| `spectrum_mask` | `(B, n_peaks)` | Which spectrum positions are real peaks. |
+
+Both are propagated through:
+
+- `encode_spectrum` — `spectrum_mask` becomes `src_key_padding_mask`.
+- `forward` / `decoder` — `atom_mask` becomes `tgt_key_padding_mask`,
+  `spectrum_mask` becomes `memory_key_padding_mask`.
+- `_masked_mse` — the noise loss is normalized by the number of valid
+  atoms, not the padded length.
+- `projection_from_embeddings` — masked atoms are zeroed before the QR
+  decomposition, and masked rows/cols of `P_k` are zeroed out after.
+- `_pool_spectrum` — mean-pool over valid peaks only.
+- `_orthonormality_loss` — masked atoms are zeroed before computing
+  `V^T V`.
+
+## Constructing a padded batch
+
+The pattern used in `create_synthetic_demo_dataset`
+(`spectral_diffusion.py:1908`) is the canonical recipe:
+
+```python
+# Variable-length per example
+eig_list       # list of (n_i, k)
+mz_list        # list of (p_i,)
+intensity_list # list of (p_i,)
+
+max_atoms = max(e.shape[0] for e in eig_list)
+max_peaks = max(len(m) for m in mz_list)
+
+x0            = np.zeros((B, max_atoms, k), dtype=np.float32)
+atom_mask     = np.zeros((B, max_atoms), dtype=bool)
+mz            = np.zeros((B, max_peaks), dtype=np.float32)
+intensity     = np.zeros((B, max_peaks), dtype=np.float32)
+spectrum_mask = np.zeros((B, max_peaks), dtype=bool)
+
+for i in range(B):
+    n = eig_list[i].shape[0]
+    p = len(mz_list[i])
+    x0[i, :n, :]            = eig_list[i]
+    atom_mask[i, :n]        = True
+    mz[i, :p]               = mz_list[i]
+    intensity[i, :p]        = intensity_list[i]
+    spectrum_mask[i, :p]    = True
+```
+
+Two things worth noting:
+
+1. **Zero padding is safe.** The Laplacian eigenvector tensor is zero-padded
+   because masked positions are multiplied out before any projection or
+   orthonormality computation. Zero padding for m/z also works because those
+   positions are masked out of attention; the Fourier features at m/z=0
+   never reach the loss.
+2. **No NaNs, ever.** Pad with zeros, not NaNs. Every numerical op treats
+   zero cleanly; NaNs will propagate through log-sum-exp softmax and
+   silently corrupt gradients even on masked positions.
+
+## Alternative: build masks from sequence lengths
+
+When you have `n_atoms` and `n_peaks` as 1-D tensors, the README suggests
+the idiomatic broadcast:
+
+```python
+atom_mask     = torch.arange(max_atoms).unsqueeze(0) < n_atoms.unsqueeze(1)
+spectrum_mask = torch.arange(max_peaks).unsqueeze(0) < n_peaks.unsqueeze(1)
+```
+
+Both produce the same shape and meaning as the loop above.
+
+## Packaging into a `TrainingBatch`
+
+All the tensors plus any optional targets ride in a
+`TrainingBatch` dataclass (`spectral_diffusion.py:799`):
+
+```python
+@dataclass
+class TrainingBatch:
+    x_0: torch.Tensor                       # (B, n_atoms, k)
+    mz: torch.Tensor                        # (B, n_peaks)
+    intensity: torch.Tensor                 # (B, n_peaks)
+    atom_mask: Optional[torch.Tensor]       # (B, n_atoms) bool
+    spectrum_mask: Optional[torch.Tensor]   # (B, n_peaks) bool
+    precursor_mz: Optional[torch.Tensor]    # (B,)
+    fingerprint_targets: Optional[torch.Tensor]  # (B, fp_dim)
+    atom_count_targets: Optional[torch.Tensor]   # (B,)
+    eigenvalue_targets: Optional[torch.Tensor]   # (B, k)
+```
+
+Every field except `x_0`, `mz`, and `intensity` is optional. If you don't
+want a particular loss or aux head, just leave the corresponding field as
+`None` — the loss for that term will be skipped automatically (see
+[07 — Training losses](./07_training_losses.md)).
+
+## Why validation is strict
+
+`_validate_mask` runs on every forward pass. The cost is a handful of tensor
+ops, but it catches entire classes of silent training failures:
+
+- A spectrum row where every peak is padded (would produce NaN attention
+  weights).
+- A mask passed in as `float32` (PyTorch would silently cast and get the
+  semantics wrong).
+- A mask whose length doesn't match the tensor (off-by-one in a collator).
+
+Debug once, catch forever.
+
+Next: [05 — Forward diffusion](./05_forward_diffusion.md) explains how
+clean eigenvectors become noisy targets.

--- a/docs/04_batching_and_masks.md
+++ b/docs/04_batching_and_masks.md
@@ -50,7 +50,7 @@ Both are propagated through:
   decomposition, and masked rows/cols of `P_k` are zeroed out after.
 - `_pool_spectrum` — mean-pool over valid peaks only.
 - `_orthonormality_loss` — masked atoms are zeroed before computing
-  `V^T V`.
+  `VᵀV`.
 
 ## Constructing a padded batch
 
@@ -95,8 +95,8 @@ Two things worth noting:
 
 ## Alternative: build masks from sequence lengths
 
-When you have `n_atoms` and `n_peaks` as 1-D tensors, the README suggests
-the idiomatic broadcast:
+When you have `n_atoms` and `n_peaks` as 1-D tensors, use the following
+idiomatic broadcast:
 
 ```python
 atom_mask     = torch.arange(max_atoms).unsqueeze(0) < n_atoms.unsqueeze(1)
@@ -108,7 +108,7 @@ Both produce the same shape and meaning as the loop above.
 ## Packaging into a `TrainingBatch`
 
 All the tensors plus any optional targets ride in a
-`TrainingBatch` dataclass (`spectral_diffusion.py:799`):
+`TrainingBatch` dataclass (`spectral_diffusion.py:800`):
 
 ```python
 @dataclass

--- a/docs/05_forward_diffusion.md
+++ b/docs/05_forward_diffusion.md
@@ -1,0 +1,134 @@
+# 05 — Forward Diffusion (Adding Noise)
+
+Diffusion models define a fixed procedure for corrupting a clean signal with
+Gaussian noise over `T` timesteps. Spec2Graph uses the standard DDPM
+formulation. This doc explains the schedule and the closed-form `q_sample`
+shortcut that the trainer uses.
+
+All code references point at `DiffusionTrainer` (`spectral_diffusion.py:825`).
+
+## The schedule
+
+At construction (`spectral_diffusion.py:857`):
+
+```python
+self.betas = torch.linspace(beta_start, beta_end, n_timesteps).to(device)
+self.alphas = 1.0 - self.betas
+self.alpha_cumprod = torch.cumprod(self.alphas, dim=0)
+self.alpha_cumprod_prev = F.pad(self.alpha_cumprod[:-1], (1, 0), value=1.0)
+```
+
+Defaults are `n_timesteps=1000`, `beta_start=1e-4`, `beta_end=2e-2`. The β
+values rise linearly from tiny to moderate, so at `t=0` almost no noise is
+added per step, and at `t=T-1` each step is a noticeable perturbation.
+
+From β we derive:
+
+- `αₜ = 1 − βₜ` — how much signal survives one step.
+- `ᾱₜ = ∏ αₛ` (`s ≤ t`) — how much signal survives `t` steps.
+- `ᾱ_{t-1}` — shifted one step, with `ᾱ_{-1} := 1` (the clean signal).
+
+From those we precompute everything the forward and reverse passes need:
+
+```python
+self.sqrt_alpha_cumprod            = sqrt(ᾱ)
+self.sqrt_one_minus_alpha_cumprod  = sqrt(1 − ᾱ)
+self.sqrt_alpha_cumprod_clamped    = clamp(..., min=PROJECTION_EPS)
+self.sqrt_one_minus_alpha_cumprod_clamped = clamp(..., min=PROJECTION_EPS)
+self.sqrt_recip_alpha = sqrt(1 / α)
+self.posterior_variance = β · (1 − ᾱ_{t-1}) / (1 − ᾱ + 1e-8)
+```
+
+`PROJECTION_EPS = 1e-8` is a numerical floor. At `t = 0`, `sqrt_alpha_cumprod`
+is close to 1 and no clamp is needed. The clamped versions are used in
+`_reconstruct_x0` so we never divide by ~0.
+
+## The closed-form noising step `q_sample`
+
+DDPM's key trick: you don't have to simulate `t` individual noise-adding
+steps to get `xₜ`. A closed form does it in one shot:
+
+```
+x_t = sqrt(ᾱ_t) · x_0  +  sqrt(1 − ᾱ_t) · ε,    ε ~ 𝒩(0, I)
+```
+
+Implementation (`spectral_diffusion.py:877`):
+
+```python
+def q_sample(self, x_0, t, noise=None):
+    if noise is None:
+        noise = torch.randn_like(x_0)
+    sqrt_alpha          = self.sqrt_alpha_cumprod[t].view(-1, 1, 1)
+    sqrt_one_minus_alpha = self.sqrt_one_minus_alpha_cumprod[t].view(-1, 1, 1)
+    x_t = sqrt_alpha * x_0 + sqrt_one_minus_alpha * noise
+    return x_t, noise
+```
+
+Three details to notice:
+
+1. **`t` is per-sample.** Each example in the batch gets its own random `t`
+   (see [08 — Training loop](./08_training_loop.md)). The `.view(-1, 1, 1)`
+   reshapes the coefficients so they broadcast against `x_0`'s
+   `(B, n_atoms, k)` shape.
+2. **The noise is returned.** The model is trained to predict the noise,
+   not the clean sample, so we need `ε` to compute the loss.
+3. **Mask unaware.** `q_sample` produces noise on padding rows as well.
+   That's fine — the loss masks those out. There's a small amount of
+   compute waste, but keeping the noising op simple and branch-free is
+   worth it.
+
+## Why predict noise and not `x_0` directly?
+
+Either target is mathematically valid — they're related by
+
+```
+x_0 = (x_t − sqrt(1 − ᾱ_t) · ε) / sqrt(ᾱ_t)
+```
+
+In practice, predicting ε gives a more uniform variance across `t`, which
+makes training more stable. DDPM paper, Section 3.2, covers this; the
+trainer follows that convention.
+
+For the projection loss we still need an estimate of `x_0`. The trainer
+reconstructs it on the fly via `_reconstruct_x0` (`spectral_diffusion.py:982`):
+
+```python
+return _safe_divide(x_t - sqrt_one_minus * eps_pred, sqrt_alpha)
+```
+
+`_safe_divide` uses `PROJECTION_EPS`-clamped denominator to avoid blowups at
+`t ≈ 0`.
+
+## Device placement
+
+`self.betas = torch.linspace(...).to(device)` — all schedule tensors are
+moved to `device` at construction time. This means you need to create the
+trainer **after** the model is moved to GPU:
+
+```python
+model = Spec2GraphDiffusion(config).to("cuda")
+trainer = DiffusionTrainer(model=model, config=TrainerConfig(...), device="cuda")
+```
+
+If you ever `trainer.to(new_device)`, you'll need to move the schedule
+tensors too. There's no multi-device support built in — this is a
+single-device trainer.
+
+## Mental picture of the forward process
+
+```
+t=0    x_0  (clean eigenvectors)
+t=250  x_t  ≈ 0.89 · x_0 + 0.45 · ε        # still recognisable
+t=500  x_t  ≈ 0.50 · x_0 + 0.87 · ε        # noise dominates
+t=999  x_t  ≈ 0.00 · x_0 + 1.00 · ε        # pure noise
+```
+
+(Exact coefficients depend on the β-schedule; the point is that by the last
+timestep, `x_t` is indistinguishable from a `𝒩(0, I)` draw.)
+
+The reverse process — going from `x_999` back to `x_0` — is what the
+transformer learns. That's covered in
+[09 — Reverse diffusion](./09_reverse_diffusion.md).
+
+Next: [06 — Model architecture](./06_model_architecture.md) walks through
+the transformer used as the denoiser.

--- a/docs/06_model_architecture.md
+++ b/docs/06_model_architecture.md
@@ -1,0 +1,174 @@
+# 06 — Model Architecture
+
+`Spec2GraphDiffusion` (`spectral_diffusion.py:464`) is the neural network at
+the heart of the project. It's a standard transformer encoder/decoder with
+a few conditioning tricks: the encoder sees the mass spectrum, the decoder
+sees noisy eigenvectors together with the diffusion timestep, and
+cross-attention bridges the two.
+
+This doc describes the layers, the forward pass, and the optional auxiliary
+heads.
+
+## Configuration
+
+Everything tunable lives in `Spec2GraphDiffusionConfig`
+(`spectral_diffusion.py:446`):
+
+```python
+@dataclass
+class Spec2GraphDiffusionConfig:
+    d_model: int = 256
+    nhead: int = 8
+    num_encoder_layers: int = 4
+    num_decoder_layers: int = 4
+    dim_feedforward: int = 1024
+    k: int = 8                              # number of eigenvectors predicted
+    max_atoms: int = 64                     # max sequence length on decoder side
+    max_peaks: int = 100                    # max sequence length on encoder side
+    dropout: float = 0.1
+    fingerprint_dim: int = 0                # 0 disables fingerprint head
+    enable_atom_count_head: bool = False
+    enable_eigenvalue_head: bool = False
+    enable_precursor_conditioning: bool = False
+```
+
+`max_atoms` and `max_peaks` are not just hyperparameters — `atom_pos_embedding`
+is a `nn.Embedding(max_atoms, d_model)`, so exceeding `max_atoms` at runtime
+raises a clear error (`spectral_diffusion.py:684`).
+
+## Components, one by one
+
+### Spectrum side (the encoder)
+
+| Piece | Purpose |
+|-------|---------|
+| `FourierMzEmbedding(d_model)` | Project each m/z to a `d_model` vector using sinusoidal features. |
+| `IntensityEmbedding(d_model)` | Linear projection of intensity. |
+| Sum them | Combined peak representation. |
+| `TransformerEncoder(num_encoder_layers)` | Self-attention over peaks (padded positions masked). |
+| `LayerNorm` (`encoder_norm`) | Stabilize the output. |
+| (optional) `precursor_embedding` + `precursor_fusion` | Inject a global precursor-m/z token. |
+
+See [03 — Spectrum encoding](./03_spectrum_encoding.md) for the details.
+
+### Atom side (the decoder)
+
+| Piece | Purpose |
+|-------|---------|
+| `eigenvec_in = Linear(k, d_model)` | Embed noisy eigenvector rows as tokens. |
+| `atom_pos_embedding` | Learned positional embedding across `max_atoms`. |
+| `TimestepEmbedding(d_model)` | Sinusoidal + MLP embedding for `t`. |
+| `TransformerDecoder(num_decoder_layers)` | Self-attends over atoms and cross-attends to spectrum memory. |
+| `LayerNorm` (`decoder_norm`) | Stabilize. |
+| `eigenvec_out = Linear(d_model, k)` | Project back to eigenvector space — predicts **noise**, not eigenvectors. |
+
+### Auxiliary heads (optional)
+
+All three heads operate on the pooled spectrum representation, so they
+don't need the decoder. They are light MLPs wired up conditionally in
+`__init__`:
+
+| Head | Gate | Output |
+|------|------|--------|
+| `fingerprint_head` | `fingerprint_dim > 0` | `(B, fingerprint_dim)` logits — Morgan fingerprint prediction. |
+| `atom_count_head` | `enable_atom_count_head=True` | `(B,)` regression — number of atoms. |
+| `eigenvalue_head` | `enable_eigenvalue_head=True` | `(B, k)` regression — Laplacian eigenvalues. |
+
+Each has a corresponding `predict_*` method that re-runs `encode_spectrum`
+and `_pool_spectrum` before invoking the head.
+
+## The main `forward` pass
+
+Source at `spectral_diffusion.py:657`.
+
+Inputs:
+- `x_t`: noisy eigenvectors `(B, n_atoms, k)`
+- `t`: timestep `(B,)` long
+- `mz`, `intensity`: `(B, n_peaks)`
+- `atom_mask`, `spectrum_mask`: `(B, *)` bool, True=valid
+- `precursor_mz`: `(B,)` or None
+
+Output:
+- `ε̂`: predicted noise `(B, n_atoms, k)`
+
+The flow inside the method:
+
+```python
+# 1. encode spectrum
+memory = self.encode_spectrum(mz, intensity, spectrum_mask, precursor_mz)
+# 2. timestep embedding
+t_emb = self.time_embedding(t)                          # (B, d_model)
+# 3. embed noisy eigenvectors
+x_emb = self.eigenvec_in(x_t)                           # (B, n_atoms, d_model)
+# 4. add positional + timestep
+pos_emb = self.atom_pos_embedding(torch.arange(n_atoms))  # (n_atoms, d_model)
+x_emb = x_emb + pos_emb + t_emb.unsqueeze(1)
+# 5. decode with cross-attention to memory
+tgt_key_padding_mask    = ~atom_mask     if atom_mask     is not None else None
+memory_key_padding_mask = ~spectrum_mask if spectrum_mask is not None else None
+decoded = self.decoder(
+    x_emb, memory,
+    tgt_key_padding_mask=tgt_key_padding_mask,
+    memory_key_padding_mask=memory_key_padding_mask,
+)
+decoded = self.decoder_norm(decoded)
+# 6. project back to eigenvector space (predicts noise)
+return self.eigenvec_out(decoded)
+```
+
+Four things worth understanding:
+
+1. **Timestep addition, not concatenation.** `t_emb` has shape
+   `(B, d_model)` and is added with `.unsqueeze(1)` so the same timestep
+   contribution is applied to every atom token. This keeps the sequence
+   length unchanged and is how most DDPM denoisers wire `t` in.
+2. **Positional embedding is on atom indices.** This is what prevents
+   the model from being permutation-invariant. If you want order-invariance,
+   you'd need to replace this with a set-style encoding and rethink the
+   atom_count head.
+3. **Output shape equals input shape.** The decoder is essentially a
+   conditional denoiser: given a noisy `V_k`, predict the noise you'd need
+   to remove.
+4. **Cross-attention bridges the two modalities.** Each layer of
+   `TransformerDecoder` has a cross-attention block that lets atom tokens
+   pull features from spectrum tokens. This is where "condition on the
+   spectrum" is implemented.
+
+## Input validation
+
+`encode_spectrum` checks:
+
+- `mz.dim() == 2`, `intensity.dim() == 2`
+- `mz.shape == intensity.shape`
+- `mz.shape[1] <= max_peaks`
+- `precursor_mz.shape == (B,)` if provided
+
+`forward` also checks `n_atoms <= max_atoms` and validates masks via
+`_validate_mask`. These are all cheap and fire before any heavy compute,
+so you get an instant, descriptive error instead of a shape-broadcasting
+surprise deep in the transformer.
+
+## Parameter count at default config
+
+The demo (`run_demo`) prints the parameter count after construction. With the
+defaults (`d_model=256`, 4+4 layers, `k=8`, `max_atoms=64`, `max_peaks=100`)
+you get ~5M parameters. The demo halves that by using `d_model=128` and 2+2
+layers.
+
+## Extending the model
+
+Common modifications map onto specific hooks:
+
+- **Different m/z encoding.** Swap `FourierMzEmbedding` for a learned MLP
+  or a Gaussian-mixture kernel. Just preserve the `(B, n_peaks, d_model)`
+  output shape.
+- **New conditioning signal.** Copy the precursor-conditioning path:
+  embed it, mean-pool the encoded spectrum, fuse, broadcast. This is the
+  cleanest way to add new global context.
+- **Alternative decoder.** You can replace the `TransformerDecoder` with
+  a graph neural operator (the SGNO lives in the same file for exactly
+  this reason), but you'd need to handle the timestep and positional
+  conditioning yourself.
+
+Next: [07 — Training losses](./07_training_losses.md) covers what the model
+is actually optimised for.

--- a/docs/06_model_architecture.md
+++ b/docs/06_model_architecture.md
@@ -12,7 +12,7 @@ heads.
 ## Configuration
 
 Everything tunable lives in `Spec2GraphDiffusionConfig`
-(`spectral_diffusion.py:446`):
+(`spectral_diffusion.py:447`):
 
 ```python
 @dataclass

--- a/docs/07_training_losses.md
+++ b/docs/07_training_losses.md
@@ -2,7 +2,7 @@
 
 Training Spec2Graph is a weighted sum of up to five loss terms. Only the
 first is required; the rest are opt-in via `TrainerConfig`
-(`spectral_diffusion.py:813`):
+(`spectral_diffusion.py:814`):
 
 ```python
 @dataclass

--- a/docs/07_training_losses.md
+++ b/docs/07_training_losses.md
@@ -1,0 +1,211 @@
+# 07 — Training Losses
+
+Training Spec2Graph is a weighted sum of up to five loss terms. Only the
+first is required; the rest are opt-in via `TrainerConfig`
+(`spectral_diffusion.py:813`):
+
+```python
+@dataclass
+class TrainerConfig:
+    n_timesteps: int = 1000
+    beta_start: float = 0.0001
+    beta_end: float = 0.02
+    projection_loss_weight: float = 1.0
+    orthonormality_loss_weight: float = 0.0
+    fingerprint_loss_weight: float = 0.0
+    atom_count_loss_weight: float = 0.0
+    eigenvalue_loss_weight: float = 0.0
+```
+
+All of the math below is implemented in `DiffusionTrainer.compute_loss`
+(`spectral_diffusion.py:1137`).
+
+## 1. Noise MSE (required, primary)
+
+The DDPM objective:
+
+```
+L_noise = E_t ‖ ε̂(x_t, t, spectrum) − ε ‖²
+```
+
+Implementation (`spectral_diffusion.py:1176`):
+
+```python
+noise_loss = self._masked_mse(
+    predicted_noise, noise,
+    mask=atom_mask.unsqueeze(-1) if atom_mask is not None else None,
+)
+loss = noise_loss
+```
+
+`_masked_mse` (`spectral_diffusion.py:965`) averages only over valid atoms:
+
+```python
+diff = (pred - target) ** 2
+per_item = (diff * mask).view(diff.shape[0], -1).sum(dim=1)
+denom = mask.view(mask.shape[0], -1).sum(dim=1).clamp_min(PROJECTION_EPS)
+return (per_item / denom).mean()
+```
+
+That prevents padded positions from inflating the denominator (a mistake
+that would tell you training is going well when really the loss is just
+getting diluted by zeros).
+
+This term alone would train a valid DDPM, but it's weak because the target
+eigenvectors suffer from the sign/rotation ambiguity described in
+[02 — Data processing](./02_data_processing.md). That's where the next
+term comes in.
+
+## 2. Projection loss `‖P̂_k − P_k‖²_F` (required by convention)
+
+Default weight is `projection_loss_weight = 1.0`, so this is on by default.
+The trainer:
+
+1. Reconstructs a Tweedie-style estimate of the clean sample from the
+   predicted noise (`_reconstruct_x0`, L982).
+2. Builds the projection matrix from the predicted and ground-truth
+   eigenvectors via QR-orthonormalization (`projection_from_embeddings`, L900).
+3. Computes a mask-aware MSE of the two projections.
+
+```python
+x_0_pred = self._reconstruct_x0(x_t, predicted_noise, sqrt_alpha, sqrt_one_minus)
+proj_pred   = self.projection_from_embeddings(x_0_pred, atom_mask)
+proj_target = self.projection_from_embeddings(x_0,      atom_mask)
+mask_matrix = atom_mask.unsqueeze(-1) * atom_mask.unsqueeze(-2)
+proj_loss = self._masked_mse(proj_pred, proj_target, mask=mask_matrix)
+loss += self.projection_loss_weight * proj_loss
+```
+
+### Why QR?
+
+Raw `V̂ V̂ᵀ` is only a true orthogonal projector if `V̂` is orthonormal,
+which the model isn't guaranteed to produce (especially early in training).
+Taking the QR of `V̂`'s column space gives a proper orthonormal basis
+`Q` first, then `P = Q Qᵀ`. Both predictions and targets go through the
+same operation so they stay comparable.
+
+### Why a mask matrix for the MSE?
+
+`P_k` is `(n_atoms, n_atoms)`. Padded atoms should contribute nothing.
+The outer product `atom_mask ⊗ atom_mask` gives a row/col mask: only
+entries where both endpoints are real atoms count.
+
+### A warning
+
+For large `n_atoms`, allocating the full `(B, N, N)` tensor is expensive.
+`projection_from_embeddings` warns once when `n_atoms >
+PROJECTION_WARNING_THRESHOLD = 256` (L35).
+
+## 3. Orthonormality regularizer (optional)
+
+Even though the subspace-invariant projection loss handles the ambiguity
+issue, sometimes you also want the predicted eigenvectors to be
+approximately orthonormal — e.g., if you plan to use them directly rather
+than via `P_k`. Enable this with `orthonormality_loss_weight > 0`.
+
+Implementation (`spectral_diffusion.py:993`):
+
+```python
+gram = V̂ᵀ V̂                     # (B, k, k)
+I_k  = identity(k)
+L_ortho = mean( (gram - I_k)² )
+```
+
+This penalty encourages `V̂` to sit on the Stiefel manifold (columns
+orthonormal). Padded atoms are zeroed out first, so they don't artificially
+inflate or deflate the Gram matrix.
+
+## 4. Fingerprint head (optional)
+
+Enable with:
+- `Spec2GraphDiffusionConfig.fingerprint_dim = 2048` (or whatever bit count).
+- `TrainerConfig.fingerprint_loss_weight > 0`.
+- Provide `TrainingBatch.fingerprint_targets` as a `(B, fp_dim)` binary
+  tensor.
+
+The head runs **only on the spectrum** — no diffusion, no eigenvectors:
+
+```python
+fp_logits = self.model.predict_fingerprint(mz, intensity, spectrum_mask, precursor_mz)
+fingerprint_loss = F.binary_cross_entropy_with_logits(fp_logits, fingerprint_targets)
+loss += self.fingerprint_loss_weight * fingerprint_loss
+```
+
+This gives the spectrum encoder a second, easier gradient signal: predict
+which Morgan bits the molecule has. It acts as a regularizer and makes the
+encoder's internal representation more chemistry-aware.
+
+## 5. Atom count head (optional)
+
+Enable with:
+- `Spec2GraphDiffusionConfig.enable_atom_count_head = True`.
+- `TrainerConfig.atom_count_loss_weight > 0`.
+- Provide `TrainingBatch.atom_count_targets` (float, shape `(B,)`).
+
+Loss: plain MSE on a scalar regression. Why bother? At inference, if you
+don't know the atom count in advance, the sampler can call
+`model.predict_atom_count` to decide how many atom slots to generate
+(see [09 — Reverse diffusion](./09_reverse_diffusion.md)).
+
+## 6. Eigenvalue head (optional, Phase 4)
+
+Enable with:
+- `Spec2GraphDiffusionConfig.enable_eigenvalue_head = True`.
+- `TrainerConfig.eigenvalue_loss_weight > 0`.
+- Provide `TrainingBatch.eigenvalue_targets` shape `(B, k)`.
+
+```python
+eig_pred = self.model.predict_eigenvalues(mz, intensity, spectrum_mask, precursor_mz)
+eigenvalue_loss = F.mse_loss(eig_pred, eigenvalue_targets)
+loss += self.eigenvalue_loss_weight * eigenvalue_loss
+```
+
+Laplacian eigenvalues encode graph invariants (connectivity, bipartiteness,
+approximate edge count). Predicting them both regularizes the encoder and
+enables the eigenvalue-conditioned decoder in
+[11 — Advanced features](./11_advanced_features.md).
+
+## Combined objective
+
+```
+L = L_noise
+  + w_proj   · L_proj            (projection, default 1.0)
+  + w_ortho  · L_ortho           (optional)
+  + w_fp     · L_fingerprint     (optional)
+  + w_count  · L_atom_count      (optional)
+  + w_eig    · L_eigenvalues     (optional)
+```
+
+## Inspecting individual components
+
+`compute_loss` accepts `return_components=True`:
+
+```python
+loss, comps = trainer.compute_loss(batch, return_components=True)
+# comps = {
+#   "noise": ..., "projection": ..., "orthonormality": ...,
+#   "fingerprint": ..., "atom_count": ..., "eigenvalue": ...,
+# }
+```
+
+The demo prints noise, projection, fingerprint, and atom_count side by
+side so you can watch each term evolve. This is very useful when you're
+tuning the weights — if the projection loss flatlines but noise keeps
+falling, the subspace signal isn't being learned.
+
+## A note on the reconstruction shortcut
+
+Both `L_proj` and `L_ortho` need `x_0` on the prediction side. Rather than
+run a separate forward pass to predict `x_0` directly, the trainer uses
+Tweedie's formula on the predicted noise:
+
+```python
+x_0_pred = (x_t − sqrt(1 − ᾱ_t) · ε̂) / sqrt(ᾱ_t)
+```
+
+This is **exact** algebra on the closed-form `q_sample` equation, so no
+extra approximation is introduced — it's just the same relationship
+rearranged.
+
+Next: [08 — Training loop](./08_training_loop.md) assembles all of this
+into a single `train_step`.

--- a/docs/08_training_loop.md
+++ b/docs/08_training_loop.md
@@ -154,9 +154,15 @@ Scaling this up to a real training script typically means adding:
 ```python
 from torch.utils.data import DataLoader
 
+def _to_device(t, device):
+    return t.to(device) if torch.is_tensor(t) else t
+
 for epoch in range(num_epochs):
-    for raw_batch in dataloader:          # your dataset yields dicts/tuples
-        batch = TrainingBatch(**raw_batch).to(device)
+    for raw_batch in dataloader:          # your dataset yields dicts of tensors
+        # TrainingBatch is a plain @dataclass with no .to() helper, so move
+        # each tensor field explicitly before constructing the batch.
+        raw_batch = {k: _to_device(v, device) for k, v in raw_batch.items()}
+        batch = TrainingBatch(**raw_batch)
         loss, comps = trainer.train_step(optimizer, batch, return_components=True)
         # log, step LR scheduler, evaluate, checkpoint, etc.
     # optional: evaluate / sample at end of epoch

--- a/docs/08_training_loop.md
+++ b/docs/08_training_loop.md
@@ -1,0 +1,197 @@
+# 08 — Training Loop
+
+The outermost layer that users touch is `DiffusionTrainer.train_step`
+(`spectral_diffusion.py:1249`). This doc walks through what happens in one
+step end-to-end and shows how to extend it to a full training script.
+
+## `train_step` in detail
+
+```python
+def train_step(self, optimizer, batch, return_components=False):
+    self.model.train()
+    optimizer.zero_grad()
+    loss, components = (
+        self.compute_loss(batch, return_components=True)
+        if return_components
+        else (self.compute_loss(batch, return_components=False), None)
+    )
+    loss.backward()
+    optimizer.step()
+    if return_components:
+        return loss.item(), {k: v.item() for k, v in components.items()}
+    return loss.item()
+```
+
+The chain of calls:
+
+1. `self.model.train()` — puts dropout/BatchNorm into training mode.
+2. `optimizer.zero_grad()` — clears the previous step's gradients.
+3. `compute_loss(batch)` — does the heavy lifting:
+    - Samples a random timestep per batch item.
+    - Calls `q_sample` to noise `x_0`.
+    - Runs a forward pass of the model.
+    - Computes the weighted sum of all enabled loss terms
+      (see [07 — Training losses](./07_training_losses.md)).
+4. `loss.backward()` — autograd over the entire graph, including through
+   `_reconstruct_x0` and `projection_from_embeddings`.
+5. `optimizer.step()` — gradient descent update.
+
+Nothing exotic — this is the shape of every PyTorch training step you've
+ever written.
+
+## What `compute_loss` does each step
+
+Reading `compute_loss` line by line (`spectral_diffusion.py:1137`):
+
+### a. Pull tensors out of the batch
+
+```python
+x_0, mz, intensity = batch.x_0, batch.mz, batch.intensity
+atom_mask, spectrum_mask = batch.atom_mask, batch.spectrum_mask
+precursor_mz = batch.precursor_mz
+fingerprint_targets   = batch.fingerprint_targets
+atom_count_targets    = batch.atom_count_targets
+eigenvalue_targets    = batch.eigenvalue_targets
+```
+
+### b. Sample a timestep and noise
+
+```python
+t = torch.randint(0, self.n_timesteps, (B,), device=self.device)
+noise = torch.randn_like(x_0)
+x_t, _ = self.q_sample(x_0, t, noise)
+```
+
+Each example in the batch gets its own timestep. At batch size 32, you
+cover 32 different noise levels per step — this is intentional and keeps
+the gradient well-conditioned across the schedule.
+
+### c. Forward through the model
+
+```python
+predicted_noise = self.model(
+    x_t, t, mz, intensity, atom_mask, spectrum_mask, precursor_mz,
+)
+```
+
+Predicts the noise that was added.
+
+### d. Accumulate losses
+
+Noise loss first (always on):
+
+```python
+noise_loss = self._masked_mse(
+    predicted_noise, noise,
+    mask=atom_mask.unsqueeze(-1) if atom_mask is not None else None,
+)
+loss = noise_loss
+```
+
+Projection + orthonormality reuse `_reconstruct_x0` to get a clean estimate:
+
+```python
+if self.projection_loss_weight > 0 or self.orthonormality_loss_weight > 0:
+    sqrt_alpha = self.sqrt_alpha_cumprod_clamped[t].view(B, 1, 1)
+    sqrt_one_minus = self.sqrt_one_minus_alpha_cumprod_clamped[t].view(B, 1, 1)
+    x_0_pred = self._reconstruct_x0(x_t, predicted_noise, sqrt_alpha, sqrt_one_minus)
+```
+
+Then each optional term is added only if its weight is > 0 and the needed
+targets are present:
+
+```python
+if self.projection_loss_weight > 0 and x_0_pred is not None:
+    ...
+    loss += self.projection_loss_weight * proj_loss
+
+if self.orthonormality_loss_weight > 0 and x_0_pred is not None:
+    ...
+    loss += self.orthonormality_loss_weight * ortho_loss
+
+if self.fingerprint_loss_weight > 0 and fingerprint_targets is not None:
+    ...
+    loss += self.fingerprint_loss_weight * fingerprint_loss
+
+# same pattern for atom_count and eigenvalue
+```
+
+Notice the guard on targets: if you forgot to pass `fingerprint_targets`
+but set `fingerprint_loss_weight > 0`, the fingerprint term is silently
+skipped. That's forgiving, but it also means a misconfigured training run
+can look like it's working when it isn't. Verify loss components
+(`return_components=True`) match your expectation for the first few steps.
+
+### e. Return
+
+`compute_loss` returns either a scalar `loss` or `(loss, components)`.
+Keep in mind the components dictionary is **detached** — it's for
+logging, not backprop.
+
+## A full training loop
+
+The demo (`spectral_diffusion.py:2075`) shows the minimal version:
+
+```python
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+
+for step in range(n_steps):
+    loss, components = trainer.train_step(
+        optimizer, batch, return_components=True,
+    )
+    if (step + 1) % 5 == 0:
+        print(
+            f"   Step {step + 1}/{n_steps}, total loss: {loss:.4f} | "
+            f"noise: {components['noise']:.4f}, "
+            f"proj: {components['projection']:.4f}, "
+            f"fp: {components['fingerprint']:.4f}, "
+            f"atoms: {components['atom_count']:.4f}"
+        )
+```
+
+Scaling this up to a real training script typically means adding:
+
+```python
+from torch.utils.data import DataLoader
+
+for epoch in range(num_epochs):
+    for raw_batch in dataloader:          # your dataset yields dicts/tuples
+        batch = TrainingBatch(**raw_batch).to(device)
+        loss, comps = trainer.train_step(optimizer, batch, return_components=True)
+        # log, step LR scheduler, evaluate, checkpoint, etc.
+    # optional: evaluate / sample at end of epoch
+```
+
+Things not built into the trainer but worth adding in a real run:
+
+- **LR scheduling** — `torch.optim.lr_scheduler.CosineAnnealingLR` or warmup
+  + cosine. The trainer doesn't touch the optimizer beyond `zero_grad` and
+  `step`, so plug in whatever.
+- **Gradient clipping** — `torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)`
+  between `backward()` and `step()`. The projection loss occasionally
+  produces spiky gradients.
+- **Mixed precision** — `torch.amp.autocast` + `GradScaler`. You'd need to
+  wrap `compute_loss` with autocast and insert `scaler.scale(loss).backward()`.
+  The trainer doesn't currently do this itself.
+- **EMA of model weights** — a very common DDPM trick that smooths sample
+  quality. Easy to bolt on outside the trainer.
+- **Checkpointing** — `torch.save({"model": model.state_dict(), "optimizer":
+  optimizer.state_dict(), "config": config})`.
+
+## Common issues and diagnoses
+
+- **Noise loss stays high, projection low.** You're underfitting the
+  denoising task. Increase model capacity, reduce projection weight
+  temporarily, or check that the forward process is working correctly
+  (plot `x_t` vs `x_0`).
+- **Projection loss stays high, noise loss low.** The predicted noise is
+  accurate in magnitude but not pointing the right way for subspace
+  recovery. Try enabling the orthonormality term.
+- **NaNs.** Almost always stem from a padded batch with an all-False row
+  slipping past `_validate_mask`, or an `eigh` of a badly-conditioned
+  Laplacian. Instrument with `torch.isnan(x).any()` at each stage.
+- **Exploding losses early.** Lower the LR, add gradient clipping, or
+  warm up the projection weight from 0 to its target.
+
+Next: [09 — Reverse diffusion](./09_reverse_diffusion.md) turns the
+trained model around to generate eigenvectors from a spectrum.

--- a/docs/09_reverse_diffusion.md
+++ b/docs/09_reverse_diffusion.md
@@ -94,9 +94,12 @@ Two pragmatic choices here:
   still predict different atom counts — they're distinguished via the
   auto-constructed `atom_mask`. Padding up to the batch max is the cheapest
   way to keep a single dense tensor.
-- **Relies on the atom-count head being trained.** If you never set
-  `enable_atom_count_head=True`, this branch raises a clear error because
-  `predict_atom_count` is `None`.
+- **Relies on the atom-count head being enabled.** `predict_atom_count`
+  always exists on the model, but if you never set
+  `enable_atom_count_head=True` it raises a `ValueError` at call time:
+  *"Atom count head is disabled. Set enable_atom_count_head=True to enable
+  predictions."* So `sample(..., n_atoms=None)` will fail fast with that
+  message rather than silently producing garbage.
 
 ### Constructing `x_T`
 

--- a/docs/09_reverse_diffusion.md
+++ b/docs/09_reverse_diffusion.md
@@ -1,0 +1,184 @@
+# 09 — Reverse Diffusion (Sampling)
+
+At inference the diffusion runs in reverse: start from pure Gaussian
+noise, denoise one step at a time conditioned on the mass spectrum, and
+end up with a clean `V̂_k` that the decoder can turn into bonds.
+
+Two functions implement this: `p_sample` for a single step, and `sample`
+for the whole loop.
+
+## `p_sample`: one reverse step
+
+Source at `spectral_diffusion.py:1016`.
+
+Given `x_t` and the current timestep `t`, produce `x_{t-1}`:
+
+```python
+with torch.no_grad():
+    predicted_noise = self.model(
+        x_t, t_tensor, mz, intensity, atom_mask, spectrum_mask, precursor_mz,
+    )
+
+alpha         = self.alphas[t]
+alpha_cumprod = self.alpha_cumprod[t]
+beta          = self.betas[t]
+
+# Mean of p(x_{t-1} | x_t)
+mean = (1.0 / torch.sqrt(alpha)) * (
+    x_t - (beta / torch.sqrt(1.0 - alpha_cumprod)) * predicted_noise
+)
+
+if t > 0:
+    noise    = torch.randn_like(x_t)
+    variance = self.posterior_variance[t]
+    x_t_minus_1 = mean + torch.sqrt(variance) * noise
+else:
+    x_t_minus_1 = mean
+
+return x_t_minus_1
+```
+
+This is the DDPM paper's Algorithm 2 sample line. Two things to note:
+
+1. **Stochastic until the last step.** At every `t > 0` we add
+   `sqrt(posterior_variance) · noise`. At `t = 0` we take the mean
+   deterministically — adding noise at the final step would just hurt
+   sample quality.
+2. **`torch.no_grad()`.** Gradients aren't needed during sampling.
+   `GuidedDiffusionSampler` (see
+   [11 — Advanced features](./11_advanced_features.md)) intentionally
+   re-enables gradients for its Tweedie step.
+
+## `sample`: the full loop
+
+Source at `spectral_diffusion.py:1069`. Signature:
+
+```python
+@torch.no_grad()
+def sample(
+    self,
+    mz, intensity,
+    n_atoms=None,
+    atom_mask=None,
+    spectrum_mask=None,
+    precursor_mz=None,
+    x_t=None,
+):
+```
+
+### Determining `n_atoms`
+
+If you know how many heavy atoms the target molecule has, pass `n_atoms`
+directly. If you don't, the sampler uses the optional atom-count head:
+
+```python
+if n_atoms is None:
+    count_pred = self.model.predict_atom_count(
+        mz, intensity, spectrum_mask, precursor_mz,
+    )
+    n_atoms_per_sample = torch.clamp(
+        torch.round(count_pred), 1, self.model.max_atoms,
+    ).long()
+    n_atoms = int(n_atoms_per_sample.max().item())
+    if atom_mask is None:
+        atom_mask = (
+            torch.arange(n_atoms, device=self.device).unsqueeze(0)
+                .expand(batch_size, -1)
+            < n_atoms_per_sample.unsqueeze(1)
+        )
+```
+
+Two pragmatic choices here:
+
+- **Sequence length is the max count in the batch.** Different examples can
+  still predict different atom counts — they're distinguished via the
+  auto-constructed `atom_mask`. Padding up to the batch max is the cheapest
+  way to keep a single dense tensor.
+- **Relies on the atom-count head being trained.** If you never set
+  `enable_atom_count_head=True`, this branch raises a clear error because
+  `predict_atom_count` is `None`.
+
+### Constructing `x_T`
+
+By default, start from pure Gaussian noise of shape `(B, n_atoms, k)`:
+
+```python
+x_t = torch.randn(batch_size, n_atoms, k, device=self.device)
+```
+
+You can also pass your own `x_t` — useful for partial-noise "editing" or
+deterministic reruns with a seeded tensor.
+
+### The reverse loop
+
+```python
+for t in reversed(range(self.n_timesteps)):
+    x_t = self.p_sample(
+        x_t, t, mz, intensity, atom_mask, spectrum_mask, precursor_mz,
+    )
+return x_t
+```
+
+At `n_timesteps = 1000` that's a thousand forward passes through the
+transformer. With batch size 1 on CPU this is slow; with a GPU and batch
+size 32 it's tolerable but not instant. Speed-ups commonly used elsewhere:
+
+- **DDIM sampler.** Deterministic, supports subsampling the schedule
+  (e.g., 50 steps). Not implemented here but a natural drop-in.
+- **Fewer training timesteps.** The demo uses `n_timesteps=100`, which
+  makes sampling tractable for a quick demo.
+
+## Using the sample
+
+The output is `V̂_k ∈ ℝ^{B × n_atoms × k}` — the model's best estimate of
+the target eigenvectors, matched to the input spectrum.
+
+You can evaluate the subspace similarity against known targets with
+`projection_from_embeddings`:
+
+```python
+target_proj = DiffusionTrainer.projection_from_embeddings(x_0[:1], mask=atom_mask[:1])
+gen_proj    = DiffusionTrainer.projection_from_embeddings(generated.cpu())
+sim = F.mse_loss(gen_proj, target_proj)
+```
+
+That's exactly what the demo prints at the end as "projection similarity
+(lower is better)".
+
+For a full molecule reconstruction, feed `V̂_k` into a decoder — see
+[10 — Prediction decoders](./10_prediction_decoders.md).
+
+## Implementation subtleties worth knowing
+
+### Mask handling during sampling
+
+The model's `forward` validates masks on every call. That includes every
+one of the ~1000 steps in `p_sample`. The cost is negligible but make sure
+the masks you pass are compatible with the batch at all times — if you
+construct them on the fly from predicted atom counts, double-check you
+aren't creating all-False rows.
+
+### Timestep tensor
+
+`p_sample` wraps `t` as `torch.full((B,), t, device=..., dtype=torch.long)`.
+The model's `TimestepEmbedding` expects a 1-D long tensor per batch item,
+so this broadcast is required — passing a scalar silently fails because
+the sinusoidal expansion treats `(B, d_model)` and `(d_model,)` shapes
+very differently.
+
+### Running on CPU
+
+Everything supports CPU; the schedule tensors live on `device` and the
+model moves with `.to(device)`. With defaults, one `p_sample` call on
+CPU is milliseconds; the whole reverse loop is tens of seconds for
+`n_timesteps=1000`. Fine for debugging, not for production.
+
+### Deterministic sampling
+
+To reproduce a sample exactly, seed `torch.manual_seed` before calling
+`sample` — but only if you also pass a pre-computed `x_t`. The two sources
+of randomness in the loop are the initial noise and the per-step noise,
+and both go through the default PyTorch RNG.
+
+Next: [10 — Prediction decoders](./10_prediction_decoders.md) turns the
+generated eigenvectors into an actual molecular graph.

--- a/docs/10_prediction_decoders.md
+++ b/docs/10_prediction_decoders.md
@@ -1,0 +1,226 @@
+# 10 — Prediction Decoders
+
+Once reverse diffusion yields `V̂_k`, we still need to turn those
+eigenvectors into a molecular graph — i.e., an adjacency matrix. Spec2Graph
+ships two decoders that handle different stages of that:
+
+1. **`SpectralGraphNeuralOperator` (SGNO)** — neural, differentiable,
+   produces continuous bond probabilities.
+2. **`ValencyDecoder`** — symbolic, discrete, enforces chemical valency.
+
+You typically use both: SGNO first, then `ValencyDecoder` on its output.
+
+## SpectralGraphNeuralOperator
+
+Defined at `spectral_diffusion.py:1297`.
+
+### Idea
+
+Treat each predicted eigenvector row `E_i ∈ ℝ^k` as **coordinates** for
+atom `i` on a continuous manifold. Two atoms connected by a bond should
+live "close together" in this coordinate system. A small MLP evaluates a
+learnable kernel on every pair:
+
+```
+bond_logit(i, j) = MLP([E_i ; E_j])
+```
+
+After symmetrizing and zeroing the diagonal, that becomes an adjacency
+logit matrix.
+
+### Construction
+
+```python
+SpectralGraphNeuralOperator(k=8, hidden_dim=128, num_layers=3)
+```
+
+- `k` must match the eigenvector dimension from the diffusion model.
+- `hidden_dim` and `num_layers` control the size of the pairwise MLP.
+
+The MLP structure is:
+
+```
+Linear(2k, hidden) → ReLU → Linear(hidden, hidden) → ReLU → … → Linear(hidden, 1)
+```
+
+### Forward pass (the memory-efficient bit)
+
+A naïve implementation would allocate the full `(B, N, N, 2k)`
+concatenation tensor and forward it through the first linear layer. That
+uses `O(N² · 2k)` memory per batch item. Instead, the code splits the
+first layer's weight in half, applies each half independently to the node
+embeddings, and adds them via broadcasting:
+
+```python
+first_layer = self.pairwise_mlp[0]
+w_i = first_layer.weight[:, :k]
+w_j = first_layer.weight[:, k:]
+
+out_i = F.linear(embeddings, w_i)       # (B, N, hidden)
+out_j = F.linear(embeddings, w_j)       # (B, N, hidden)
+if first_layer.bias is not None:
+    out_i = out_i + first_layer.bias
+x = out_i.unsqueeze(2) + out_j.unsqueeze(1)   # (B, N, N, hidden)
+```
+
+This is mathematically identical to the concat+linear version but never
+materializes the `2k` intermediate. For `N ≈ 64` the saving is modest;
+for `N ≈ 256` it's substantial.
+
+### Outputs
+
+Three complementary methods:
+
+| Method | Returns |
+|--------|---------|
+| `forward(E)` | Logits `(B, N, N)`, symmetric, diagonal zeroed. |
+| `bond_probabilities(E)` | `sigmoid(logits)`, diagonal zeroed. |
+| `decode_to_adjacency(E, threshold=0.5)` | Binary adjacency `(B, N, N)`. |
+
+`_zero_diagonal` (`spectral_diffusion.py:1327`) enforces a strict square-
+matrix contract: it raises if you hand it a non-square tensor. This
+catches bugs where the upstream code accidentally rectangularized a batch.
+
+### Training the SGNO
+
+The SGNO is **not** trained by `DiffusionTrainer`. If you want it to learn
+meaningful adjacency logits you need a separate training loop with a
+binary cross-entropy or BCEWithLogitsLoss target from ground-truth
+adjacency matrices — typically on pairs `(V_k_target, A_target)`.
+
+The standard recipe is:
+
+```python
+sgno = SpectralGraphNeuralOperator(k=k).to(device)
+opt = torch.optim.Adam(sgno.parameters(), lr=1e-4)
+
+for batch in dataloader:
+    V_k = batch.eigenvectors          # ground-truth V_k for the molecule
+    A   = batch.adjacency             # ground-truth adjacency
+    logits = sgno(V_k)
+    loss = F.binary_cross_entropy_with_logits(logits, A)
+    opt.zero_grad(); loss.backward(); opt.step()
+```
+
+At inference, you feed it the *predicted* `V̂_k` from the diffusion
+sampler.
+
+## ValencyDecoder
+
+Defined at `spectral_diffusion.py:1673`. This is a deterministic
+post-processing step that turns continuous bond probabilities into a
+chemically valid adjacency matrix.
+
+### Why it exists
+
+Naïvely thresholding `bond_probabilities` at 0.5 can produce atoms with
+impossible valency — e.g., a carbon bonded to six other atoms. Real
+chemistry has hard constraints:
+
+```python
+VALENCY_TABLE = {
+    "C": 4, "N": 3, "O": 2, "S": 2, "P": 3, "F": 1, "Cl": 1, "Br": 1,
+    "I": 1, "Si": 4, "B": 3, "Se": 2,
+}
+```
+
+### Algorithm
+
+A greedy "edge-by-edge" decoder:
+
+```python
+candidates = [(prob, i, j) for i<j if prob[i,j] >= threshold]
+candidates.sort(reverse=True)              # strongest bonds first
+
+remaining = [valency[a] for a in atom_types]
+for prob, i, j in candidates:
+    feasible = min(remaining[i], remaining[j], max_bond_order)
+    if feasible > 0:
+        adjacency[i, j] = feasible
+        adjacency[j, i] = feasible
+        remaining[i] -= feasible
+        remaining[j] -= feasible
+```
+
+Strongest-first ensures the most confident bonds are placed before the
+budget runs out. `max_bond_order=1` only ever places single bonds; increase
+it if you want to allow doubles/triples (you'll also need your probabilities
+to encode order, not just presence).
+
+### Signature
+
+```python
+decoder = ValencyDecoder()
+adj = decoder.decode(
+    atom_types=["C", "C", "O"],
+    bond_probs=np.array([[0.1, 0.9, 0.8],
+                         [0.9, 0.1, 0.3],
+                         [0.8, 0.3, 0.1]]),
+    threshold=0.3,
+    max_bond_order=1,
+)
+```
+
+Or batched:
+
+```python
+adjs = decoder.decode_batch(
+    atom_types_batch=[["C", "C", "O"], ["N", "N"]],
+    bond_probs_batch=probs,                 # (B, N_max, N_max)
+    threshold=0.3,
+)
+```
+
+Note: `decode_batch` expects a list of atom-type lists — one per molecule
+— because the atom count can vary. Each result is a plain `numpy` array.
+
+### `threshold` and `max_bond_order`
+
+- Low threshold (e.g., 0.2): more candidate edges, fuller molecules,
+  slower.
+- High threshold (e.g., 0.7): sparser outputs; atoms may end up
+  disconnected.
+- `max_bond_order > 1`: allows multi-bond assignment in a single
+  iteration. Only useful if your probabilities actually distinguish
+  order.
+
+### Unknown elements
+
+`get_valency` (`spectral_diffusion.py:1696`) returns `default_valency=4`
+for any element not in `VALENCY_TABLE`. For exotic elements, subclass
+or pass a custom `valency_table` at construction.
+
+## Putting SGNO and ValencyDecoder together
+
+```python
+# After reverse diffusion
+V_hat = trainer.sample(mz, intensity, n_atoms=N, spectrum_mask=spec_mask)
+
+# Neural decoding to continuous probabilities
+sgno = SpectralGraphNeuralOperator(k=k).to(device)
+bond_probs = sgno.bond_probabilities(V_hat)                         # (B, N, N)
+
+# Symbolic decoding to chemically valid graph
+atom_types = [...]  # list of element symbols per atom (from formula prediction, e.g.)
+valency_decoder = ValencyDecoder()
+adj = valency_decoder.decode(
+    atom_types=atom_types,
+    bond_probs=bond_probs[0].cpu().numpy(),
+    threshold=0.3,
+    max_bond_order=1,
+)
+```
+
+This gives you a valid single-bond adjacency ready to feed back into
+RDKit (`Chem.RWMol`) for SMILES canonicalisation.
+
+## Where this stops and where you take over
+
+Neither decoder infers *what* elements the atoms are — you provide
+`atom_types` to `ValencyDecoder`. In a full pipeline, the element
+assignment typically comes from a formula prediction head or from the
+precursor formula if it's known a priori. That's noted in `ROADMAP.md`
+under Phase 2.
+
+Next: [11 — Advanced features](./11_advanced_features.md) covers the
+optional guidance and eigenvalue-conditioning modules.

--- a/docs/11_advanced_features.md
+++ b/docs/11_advanced_features.md
@@ -1,0 +1,226 @@
+# 11 — Advanced Features
+
+Beyond the core diffusion-train-sample loop, Spec2Graph includes two
+optional systems that layer extra structure onto the pipeline:
+
+1. **Guided sampling with a GNN discriminator** — pushes reverse diffusion
+   toward chemically plausible graphs.
+2. **Eigenvalue conditioning** — injects predicted Laplacian eigenvalues
+   into the decoder to tighten the topology prior.
+
+Both are opt-in and independent of the training loop.
+
+## Guided diffusion via a GNN discriminator
+
+The idea: during reverse diffusion, at each step we have an estimate of
+the clean eigenvectors via Tweedie's formula. Decode those through the
+SGNO into a soft adjacency, score the result with a trained
+"chemistry discriminator", and use the gradient of that score to nudge
+the reverse step toward more valid structures.
+
+The plumbing spans three classes.
+
+### `DenseGNNDiscriminator`
+
+Defined at `spectral_diffusion.py:1456`. A small, differentiable GNN that
+consumes a **continuous** adjacency probability matrix and outputs a
+scalar validity score.
+
+Why dense? Standard `torch_geometric` GNNs operate on sparse edge_index
+representations, which aren't differentiable w.r.t. edge *existence*. We
+want gradients flowing through `adj_probs`, so the layer uses dense
+matrix multiplication:
+
+```python
+class DenseGNNLayer(nn.Module):
+    def forward(self, x, adj):
+        degree = adj.sum(dim=-1, keepdim=True).clamp(min=PROJECTION_EPS)
+        degree_inv_sqrt = torch.rsqrt(degree)
+        adj_norm = adj * degree_inv_sqrt * degree_inv_sqrt.transpose(-1, -2)
+        agg = torch.bmm(adj_norm, x)
+        out = self.linear(agg)
+        return F.relu(self.norm(out))
+```
+
+The discriminator stacks `num_layers` of these with residual connections,
+then mean-pools across atoms and runs a linear classifier:
+
+```python
+x = self.node_proj(degree)                  # degree-based initial features
+for layer in self.gnn_layers:
+    x = x + layer(x, adj_probs)             # residual connection
+return self.classifier(x.mean(dim=1))       # (B, 1) scalar per graph
+```
+
+Training the discriminator is **your** job — typically as a binary
+classifier on (valid graph vs. randomly perturbed graph) pairs. The repo
+doesn't ship a training loop for it.
+
+### `SpectralGraphNeuralOperator` again
+
+Already covered in [10 — Prediction decoders](./10_prediction_decoders.md).
+For guidance we use `bond_probabilities` to get a **soft** adjacency that
+the discriminator can differentiate through.
+
+### `GuidedDiffusionSampler`
+
+Defined at `spectral_diffusion.py:1517`. Construction:
+
+```python
+sampler = GuidedDiffusionSampler(
+    trainer=trainer,           # must have a trained Spec2GraphDiffusion
+    sgno=sgno,                 # trained or at least meaningful
+    discriminator=discriminator,
+    guidance_scale=1.0,        # how strongly to steer
+)
+```
+
+The core of the loop at each timestep:
+
+```python
+# 1. Standard reverse step (no grad)
+with torch.no_grad():
+    eps_pred = trainer.model(x_t, t_tensor, mz, intensity, ...)
+mu = (1/sqrt(α)) · (x_t − (β/sqrt(1−ᾱ)) · eps_pred)
+
+# 2. Tweedie estimate with gradient enabled
+if guidance_scale > 0 and t > 0:
+    x_t_grad = x_t.detach().requires_grad_(True)
+    eps_for_tweedie = trainer.model(x_t_grad, t_tensor, mz, intensity, ...)
+    x0_hat = (x_t_grad − sqrt(1−ᾱ) · eps_for_tweedie) / sqrt(ᾱ)
+
+    # Apply atom mask so padded atoms don't contribute
+    if atom_mask is not None:
+        x0_hat = x0_hat * atom_mask.unsqueeze(-1).float()
+
+    # 3. Decode and score
+    adj_probs = sgno.bond_probabilities(x0_hat)
+    if atom_mask is not None:
+        edge_mask = atom_mask.unsqueeze(-1) * atom_mask.unsqueeze(-2)
+        adj_probs = adj_probs * edge_mask
+    validity_log_prob = F.logsigmoid(discriminator(adj_probs))
+
+    # 4. Backprop through the discriminator to get a gradient on x_t
+    grad = torch.autograd.grad(validity_log_prob.sum(), x_t_grad)[0]
+
+    mu = mu + guidance_scale * grad
+
+# 5. Sample with standard variance (except at t=0)
+if t > 0:
+    noise = torch.randn_like(x_t)
+    x_t = mu + sqrt(posterior_variance[t]) * noise
+else:
+    x_t = mu
+```
+
+Things to understand:
+
+- **Two forward passes per step.** One inside `no_grad` for the standard
+  mean, one with gradients enabled to take the Tweedie derivative. That
+  ~doubles inference cost per step.
+- **`guidance_scale` is sensitive.** Too small and the guidance does
+  nothing; too large and the gradient dominates the reverse dynamics
+  and produces artifacts. Start in the `[0.1, 1.0]` range.
+- **The Tweedie shortcut is exact.** As noted in
+  [05 — Forward diffusion](./05_forward_diffusion.md), it's the analytic
+  inverse of `q_sample`, not an approximation.
+- **Mask everything.** Padded atom rows/cols of `x0_hat` and `adj_probs`
+  are zeroed before the discriminator sees them, so padding can't bias
+  the score.
+
+### When it helps
+
+Best use case: the diffusion model alone produces eigenvectors whose
+decoded adjacency *mostly* looks like a molecule but occasionally
+produces nonsense (isolated atoms, impossible valency). Guidance steers
+away from those. If the base model is simply underfit, guidance can't
+save you.
+
+## Eigenvalue conditioning
+
+The second advanced feature is wiring predicted eigenvalues into the
+decoder. Three classes collaborate.
+
+### `EigenvalueConditioner`
+
+Defined at `spectral_diffusion.py:1783`. A tiny MLP:
+
+```python
+nn.Sequential(
+    nn.Linear(k, d_model),
+    nn.ReLU(),
+    nn.Linear(d_model, d_model),
+)
+```
+
+Input: predicted eigenvalues `(B, k)`. Output: a conditioning vector
+`(B, d_model)` that encodes graph-level spectral invariants.
+
+### `Spec2GraphDiffusion.eigenvalue_head`
+
+Defined inline (`spectral_diffusion.py:554`) and wired up when
+`enable_eigenvalue_head=True`. It predicts `(B, k)` eigenvalues from the
+pooled spectrum encoding:
+
+```python
+eig_pred = model.predict_eigenvalues(mz, intensity, spectrum_mask, precursor_mz)
+```
+
+Training this head is turned on by `TrainerConfig.eigenvalue_loss_weight > 0`
+with `TrainingBatch.eigenvalue_targets` provided. See
+[07 — Training losses](./07_training_losses.md).
+
+### `EigenvalueConditionedSGNO`
+
+Defined at `spectral_diffusion.py:1820`. An extension of the plain SGNO
+whose pairwise MLP takes `[E_i ; E_j ; eigenvalue_cond]` instead of just
+`[E_i ; E_j]`:
+
+```python
+in_dim = 2*k + eigenvalue_dim
+```
+
+The forward pass splits the first linear layer into three parts
+(w_i, w_j, w_eig) and combines them with broadcasting, so it never
+materializes the full `(B, N, N, 2k + eigenvalue_dim)` tensor — same
+optimization as the base SGNO.
+
+Usage:
+
+```python
+decoder = EigenvalueConditionedSGNO(k=k, eigenvalue_dim=64).to(device)
+logits = decoder(predicted_eigenvectors, predicted_eigenvalues)
+probs  = decoder.bond_probabilities(predicted_eigenvectors, predicted_eigenvalues)
+```
+
+### Why it helps
+
+Laplacian eigenvalues of a molecular graph encode strong constraints:
+
+- The multiplicity of 0 equals the number of connected components.
+- The largest eigenvalue relates to max degree and bipartiteness.
+- The spectral sum equals the number of edges (for normalized
+  Laplacians with specific normalizations).
+
+Passing these through to the decoder means "the adjacency we're about
+to decode should produce this spectrum". In practice, it acts like a
+soft constraint that biases the decoder's edge distribution toward
+topologies consistent with the predicted invariants.
+
+## Summary
+
+| Feature | Requires training | What it gives you |
+|---------|-------------------|-------------------|
+| Guided sampling | A trained discriminator + trained SGNO | Sharper, more chemically valid samples |
+| Eigenvalue conditioning | `eigenvalue_head` trained + conditioned SGNO | Decoder that's aware of spectral invariants |
+
+Both are compatible. A full inference pipeline could:
+
+1. Run `trainer.sample` (or `GuidedDiffusionSampler.guided_sample`) to get
+   `V̂_k`.
+2. Call `model.predict_eigenvalues` on the same spectrum.
+3. Feed both into an `EigenvalueConditionedSGNO` to get bond probabilities.
+4. Finish with `ValencyDecoder` for a valid graph.
+
+Next: [12 — End-to-end walkthrough](./12_end_to_end_walkthrough.md) ties
+every chapter together with a minimal runnable example.

--- a/docs/12_end_to_end_walkthrough.md
+++ b/docs/12_end_to_end_walkthrough.md
@@ -1,0 +1,240 @@
+# 12 — End-to-End Walkthrough
+
+This doc ties every previous chapter together. It maps the exact calls in
+`run_demo()` (`spectral_diffusion.py:1987`) to the pipeline stages, then
+shows how you'd extend the demo into a "real" workflow that reaches a
+molecular graph.
+
+## The five stages of `run_demo`
+
+```
+[1] create_synthetic_demo_dataset   — builds a padded batch
+[2] Spec2GraphDiffusion(config)     — constructs the model
+[3] DiffusionTrainer(model, cfg)    — wraps the model in a DDPM trainer
+[4] trainer.train_step(...) × 20    — runs a short training loop
+[5] trainer.sample(...)             — draws one sample and scores it
+```
+
+Let's walk through each.
+
+### Stage 1 — dataset construction
+
+`create_synthetic_demo_dataset` (`spectral_diffusion.py:1908`) picks SMILES
+from a tiny pool (`benzene`, `ethanol`, `acetic acid`, `HCN`, `ethylamine`,
+`butane`, `pyridine`), runs each through `SpectralDataProcessor`, fabricates
+a plausible-looking mass spectrum, and pads everything.
+
+Outputs shape (with `batch_size=32`, `k=8`, `max_peaks=40`,
+`fingerprint_bits=128`):
+
+```
+x_0           : (32, max_atoms, 8)      # ground-truth eigenvectors
+mz            : (32, ~22)               # padded m/z
+intensity     : (32, ~22)               # padded intensities
+atom_mask     : (32, max_atoms) bool    # True = valid atom
+spectrum_mask : (32, ~22) bool          # True = valid peak
+fp_targets    : (32, 128)               # Morgan fingerprints
+atom_counts   : (32,) float             # heavy-atom counts
+```
+
+Documented in:
+- [02 — Data processing](./02_data_processing.md) — how each SMILES becomes
+  `V_k`.
+- [04 — Batching and masks](./04_batching_and_masks.md) — how everything
+  gets padded.
+
+### Stage 2 — model
+
+```python
+config = Spec2GraphDiffusionConfig(
+    d_model=128,
+    nhead=4,
+    num_encoder_layers=2,
+    num_decoder_layers=2,
+    dim_feedforward=512,
+    k=x_0.shape[-1],
+    max_atoms=x_0.shape[1],
+    max_peaks=mz.shape[1],
+    dropout=0.1,
+    fingerprint_dim=fp_targets.shape[-1],     # enables fingerprint head
+    enable_atom_count_head=True,              # enables atom count head
+)
+model = Spec2GraphDiffusion(config).to(device)
+```
+
+Note how the demo derives `max_atoms` and `max_peaks` from the batch
+itself. This is fine for a demo but not recommended for production —
+you'd typically set these to global maxima expected across your dataset.
+
+Documented in: [06 — Model architecture](./06_model_architecture.md).
+
+### Stage 3 — trainer
+
+```python
+config = TrainerConfig(
+    n_timesteps=100,            # short schedule for demo speed
+    projection_loss_weight=1.0,
+    fingerprint_loss_weight=0.1,
+    atom_count_loss_weight=0.05,
+)
+trainer = DiffusionTrainer(model=model, config=config, device=device)
+```
+
+With `n_timesteps=100`, one full sample takes 100 reverse steps instead
+of 1000. That's why the demo finishes in seconds.
+
+Documented in:
+- [05 — Forward diffusion](./05_forward_diffusion.md) — the schedule.
+- [07 — Training losses](./07_training_losses.md) — what the weights mean.
+
+### Stage 4 — training loop
+
+```python
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-4)
+batch = TrainingBatch(
+    x_0=x_0, mz=mz, intensity=intensity,
+    atom_mask=atom_mask, spectrum_mask=spectrum_mask,
+    fingerprint_targets=fp_targets,
+    atom_count_targets=atom_counts,
+)
+for step in range(20):
+    loss, components = trainer.train_step(
+        optimizer, batch, return_components=True,
+    )
+```
+
+20 steps is not enough to actually converge — the demo just shows the
+machinery. The printed components let you verify every loss term is
+non-zero and finite.
+
+Documented in: [08 — Training loop](./08_training_loop.md).
+
+### Stage 5 — sampling and evaluation
+
+```python
+model.eval()
+generated = trainer.sample(
+    mz[:1], intensity[:1],
+    n_atoms=None,                       # predicted from atom_count head
+    spectrum_mask=spectrum_mask[:1],
+)
+target_proj = DiffusionTrainer.projection_from_embeddings(x_0[:1], mask=atom_mask[:1]).cpu()
+gen_proj    = DiffusionTrainer.projection_from_embeddings(generated.cpu())
+projection_similarity = F.mse_loss(gen_proj, target_proj).item()
+```
+
+Because `n_atoms=None`, the sampler uses the atom-count head to decide
+how many atom slots to allocate. Evaluation is a projection-matrix MSE,
+which is the subspace-invariant quantity described in
+[02 — Data processing](./02_data_processing.md).
+
+Documented in: [09 — Reverse diffusion](./09_reverse_diffusion.md).
+
+## Going from the demo to a full molecule prediction
+
+The demo stops at eigenvectors. To produce a molecular graph you need one
+more pair of stages:
+
+```python
+from spectral_diffusion import (
+    SpectralGraphNeuralOperator,
+    ValencyDecoder,
+)
+
+# Assume the SGNO has been trained separately on (V_k, adjacency) pairs.
+sgno = SpectralGraphNeuralOperator(k=8).to(device)
+sgno.load_state_dict(torch.load("sgno.pt"))
+sgno.eval()
+
+with torch.no_grad():
+    bond_probs = sgno.bond_probabilities(generated)    # (1, N, N)
+
+# Atom types must come from somewhere — formula prediction, adduct parsing,
+# or priors. Here we pretend we know them.
+atom_types = ["C"] * generated.shape[1]
+
+valency_decoder = ValencyDecoder()
+adjacency = valency_decoder.decode(
+    atom_types=atom_types,
+    bond_probs=bond_probs[0].cpu().numpy(),
+    threshold=0.3,
+    max_bond_order=1,
+)
+```
+
+Documented in: [10 — Prediction decoders](./10_prediction_decoders.md).
+
+If you want guided sampling or eigenvalue conditioning, wrap the above in
+the constructs described in [11 — Advanced features](./11_advanced_features.md):
+
+```python
+from spectral_diffusion import (
+    DenseGNNDiscriminator,
+    GuidedDiffusionSampler,
+    EigenvalueConditionedSGNO,
+)
+
+discriminator = DenseGNNDiscriminator().to(device)
+discriminator.load_state_dict(torch.load("discriminator.pt"))
+discriminator.eval()
+
+guided = GuidedDiffusionSampler(
+    trainer=trainer, sgno=sgno, discriminator=discriminator, guidance_scale=0.5,
+)
+generated = guided.guided_sample(
+    mz[:1], intensity[:1], n_atoms=int(atom_counts[0]),
+    spectrum_mask=spectrum_mask[:1],
+)
+```
+
+## Checklist: "Is my training set up correctly?"
+
+Walk through this before your first long training run.
+
+- [ ] Each example's `eigenvectors` uses the same `k` and `bond_weighting`
+      as your `Spec2GraphDiffusion(k=...)` and `SpectralDataProcessor`.
+- [ ] `atom_mask` and `spectrum_mask` are **bool** tensors with at least
+      one True per row.
+- [ ] Your `max_atoms` in the config is ≥ the longest molecule in your
+      dataset — otherwise training hits a ValueError.
+- [ ] Your `max_peaks` is ≥ the longest spectrum — same reason.
+- [ ] `TrainerConfig.projection_loss_weight > 0` (default) — this is the
+      term that fixes eigenvector ambiguity.
+- [ ] If you plan to sample with `n_atoms=None`, you've set
+      `enable_atom_count_head=True` and `atom_count_loss_weight > 0` and
+      are passing `atom_count_targets`.
+- [ ] You've printed `return_components=True` for the first few steps
+      and confirmed each enabled loss is finite and non-zero.
+- [ ] Batches are on the same `device` as the trainer/model.
+- [ ] Your model was moved to `device` *before* constructing the
+      `DiffusionTrainer` (because the schedule tensors go to `device` at
+      construction time).
+
+## What's deliberately not covered
+
+Several things that would be part of a production pipeline are not
+implemented in this repo yet:
+
+- A real dataset loader (MSP/mzML parsing).
+- An SGNO or discriminator training loop.
+- DDIM-style accelerated samplers.
+- Element-aware prediction — the code always treats atoms as anonymous
+  slots and expects you to provide `atom_types` externally.
+- Formula/adduct conditioning.
+
+The `ROADMAP.md` covers the planned phases. This docs set describes
+what's already in the code.
+
+## Where to go next
+
+- To dig deeper into the math, revisit
+  [05 — Forward diffusion](./05_forward_diffusion.md) and
+  [07 — Training losses](./07_training_losses.md).
+- To extend the model, look at
+  [06 — Model architecture](./06_model_architecture.md) (hooks for new
+  conditioning) and
+  [10 — Prediction decoders](./10_prediction_decoders.md) (for decoder
+  swaps).
+- To move toward real data, the dataset constructor in
+  [04 — Batching and masks](./04_batching_and_masks.md) is the pattern
+  you want to replicate with your MSP/mzML loader.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,63 @@
+# Spec2Graph Training Pipeline — Documentation
+
+This folder walks through Spec2Graph end-to-end, from a raw mass spectrum and
+SMILES string to a predicted molecular graph. Each document covers one stage
+of the pipeline in detail so you can jump to the part you care about without
+reading the whole codebase.
+
+The full pipeline lives in a single file, [`spectral_diffusion.py`](../spectral_diffusion.py),
+and every stage referenced below points back to specific line numbers there.
+
+## Read in order
+
+1. [01 — Pipeline overview](./01_pipeline_overview.md)
+   The 10,000-ft view: what comes in, what comes out, and how the pieces fit.
+2. [02 — Data processing: SMILES to eigenvectors](./02_data_processing.md)
+   `SpectralDataProcessor`: adjacency, normalized Laplacian, sign-canonicalized
+   eigenvectors, and the projection matrix `P_k`.
+3. [03 — Spectrum encoding](./03_spectrum_encoding.md)
+   Fourier m/z features, intensity projection, and the timestep embedding.
+4. [04 — Batching and masks](./04_batching_and_masks.md)
+   Padding, mask conventions (`True = valid`), and how validation catches
+   bad batches early.
+5. [05 — Forward diffusion (adding noise)](./05_forward_diffusion.md)
+   The DDPM β-schedule, `q_sample`, and the math behind `x_t`.
+6. [06 — Model architecture](./06_model_architecture.md)
+   `Spec2GraphDiffusion`: transformer encoder/decoder, conditioning,
+   auxiliary heads.
+7. [07 — Training losses](./07_training_losses.md)
+   Noise MSE, subspace-invariant projection loss, orthonormality regularizer,
+   and the optional fingerprint / atom-count / eigenvalue heads.
+8. [08 — Training loop](./08_training_loop.md)
+   `DiffusionTrainer.train_step` — how a single gradient update is assembled.
+9. [09 — Reverse diffusion (sampling)](./09_reverse_diffusion.md)
+   `p_sample` and `sample`: going from noise back to eigenvectors at inference.
+10. [10 — Prediction decoders](./10_prediction_decoders.md)
+    SGNO kernel decoder + valency-constrained adjacency decoding.
+11. [11 — Advanced features](./11_advanced_features.md)
+    Guided diffusion with a GNN discriminator and eigenvalue-conditioned
+    decoders.
+12. [12 — End-to-end walkthrough](./12_end_to_end_walkthrough.md)
+    Tying it all together with the exact calls from `run_demo()`.
+
+## Who this is for
+
+- **New contributors** who want a map of the code before diving in.
+- **Researchers** who want to understand *why* Spec2Graph predicts a projection
+  matrix instead of raw eigenvectors.
+- **Debuggers** who want to pinpoint which stage of the pipeline is failing.
+
+## Conventions used throughout
+
+- Code references use the `path:line` format (e.g. `spectral_diffusion.py:163`)
+  so you can jump directly to the implementation.
+- Tensor shapes are annotated inline, e.g. `x_0: (batch, n_atoms, k)`.
+- Masks follow the **True = valid** convention everywhere. When a
+  `TransformerEncoder` is involved, the mask is inverted (`~mask`) because
+  PyTorch's `src_key_padding_mask` uses the opposite convention.
+- Symbols:
+  - `N` or `n_atoms` — number of atoms in a molecule
+  - `k` — number of Laplacian eigenvectors kept
+  - `T` — number of diffusion timesteps (`n_timesteps`, default 1000)
+  - `V_k` — `(N, k)` matrix of eigenvectors
+  - `P_k = V_k V_k^T` — `(N, N)` projection onto the eigen-subspace

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,4 +60,4 @@ and every stage referenced below points back to specific line numbers there.
   - `k` — number of Laplacian eigenvectors kept
   - `T` — number of diffusion timesteps (`n_timesteps`, default 1000)
   - `V_k` — `(N, k)` matrix of eigenvectors
-  - `P_k = V_k V_k^T` — `(N, N)` projection onto the eigen-subspace
+  - `P_k = V_k V_kᵀ` — `(N, N)` projection onto the eigen-subspace


### PR DESCRIPTION
## Summary

This PR adds a complete 12-chapter documentation suite that walks through the Spec2Graph diffusion model pipeline end-to-end, from raw mass spectra and SMILES strings to predicted molecular graphs. The documentation maps directly to the codebase with specific line number references.

## Key Changes

- **01 — Pipeline overview**: High-level diagram and data flow showing the two-stage process (spectrum → eigenvectors → graph)
- **02 — Data processing**: Details on converting SMILES to adjacency matrices, computing normalized Laplacians, extracting eigenvectors, and handling sign canonicalization
- **03 — Spectrum encoding**: Fourier m/z embeddings, intensity projections, timestep embeddings, and optional precursor conditioning
- **04 — Batching and masks**: Mask conventions (True=valid), validation checks, and padded batch construction patterns
- **05 — Forward diffusion**: DDPM β-schedule, closed-form `q_sample` implementation, and precomputed schedule values
- **06 — Model architecture**: Transformer encoder/decoder design, spectrum and atom-side components, auxiliary heads (fingerprint, atom count, eigenvalue)
- **07 — Training losses**: Five loss terms (noise MSE, projection, orthonormality, fingerprint, atom count, eigenvalue) with mathematical formulations and implementation details
- **08 — Training loop**: `train_step` mechanics, `compute_loss` breakdown, and full training script patterns
- **09 — Reverse diffusion**: Single-step `p_sample` and full `sample` loop, atom count prediction, and sampling strategies
- **10 — Prediction decoders**: `SpectralGraphNeuralOperator` (SGNO) for continuous bond probabilities and `ValencyDecoder` for chemically valid adjacency matrices
- **11 — Advanced features**: Guided diffusion with GNN discriminator and eigenvalue conditioning
- **12 — End-to-end walkthrough**: Maps exact calls in `run_demo()` to pipeline stages and shows how to extend the demo into a full molecule prediction workflow

## Notable Implementation Details

- All documentation includes direct code references with line numbers pointing to `spectral_diffusion.py`
- Mathematical notation is used consistently throughout (e.g., `V_k`, `P_k`, `ᾱ_t`)
- Each document includes practical code examples showing how to use the APIs
- The documentation explains design choices (e.g., why QR-orthonormalization is used for projection matrices, why the SGNO uses memory-efficient pairwise MLP computation)
- Mask conventions and validation patterns are documented to help users avoid common mistakes
- The final walkthrough chapter ties everything together and shows how to extend the demo into production workflows

https://claude.ai/code/session_01VCePHYrzLwQBJRQK8vTsd7