### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure deserialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External string inputs (SMILES) passed to RDKit's parser and tensor peak arrays passed to the Spec2Graph Transformer did not have upper bounds, leading to potential Denial of Service (DoS) attacks via memory exhaustion. RDKit and O(N^2) Transformer mechanisms are vulnerable to extreme inputs.
 **Learning:** In machine learning processing pipelines, memory-intensive modules (like molecular parsing and self-attention) must implement hard size limits on inputs before computation, even if downstream layers process it.
 **Prevention:** Always implement an initial size check (e.g., `len(smiles) <= MAX_LEN` or `mz.shape[1] <= max_peaks`) at the very edge of the API or forward pass method to drop excessively large payloads immediately.
+## 2026-04-22 - Fix insecure weights loading vulnerability
+
+**Vulnerability:** Insecure deserialization via `torch.load` with `weights_only=False` in `spec2graph/scripts/evaluate.py`.
+**Learning:** PyTorch's `torch.load` uses Python's `pickle` module by default, which can execute arbitrary code if an attacker provides a malicious checkpoint file. Setting `weights_only=True` is the required defense against this.
+**Prevention:** Always use `weights_only=True` when calling `torch.load` to load PyTorch checkpoints from untrusted sources, restricting deserialization strictly to tensors, primitive types, and dictionaries.

--- a/spec2graph/scripts/evaluate.py
+++ b/spec2graph/scripts/evaluate.py
@@ -66,7 +66,7 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - wiring onl
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 
     logger.info("Loading checkpoint %s", args.checkpoint)
-    ckpt = torch.load(args.checkpoint, map_location=args.device, weights_only=False)
+    ckpt = torch.load(args.checkpoint, map_location=args.device, weights_only=True)
     config_dict = ckpt["config"]
     trainer_dict = ckpt.get("trainer_config", {})
 
@@ -80,7 +80,7 @@ def main(argv: list[str] | None = None) -> int:  # pragma: no cover - wiring onl
     if args.sgno_checkpoint is not None:
         logger.info("Loading SGNO checkpoint %s", args.sgno_checkpoint)
         sgno_ckpt = torch.load(
-            args.sgno_checkpoint, map_location=args.device, weights_only=False
+            args.sgno_checkpoint, map_location=args.device, weights_only=True
         )
         # Pull architectural hyperparameters from the checkpoint; fall
         # back to SpectralGraphNeuralOperator defaults when a checkpoint


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Insecure deserialization via PyTorch's `torch.load` using the default `pickle` module (`weights_only=False`). An attacker could provide a malicious checkpoint file leading to arbitrary code execution.
🎯 **Impact:** Allows a malicious user providing a manipulated `.pt` checkpoint file to execute arbitrary commands on the system evaluating the model.
🔧 **Fix:** Set `weights_only=True` in `torch.load` calls within `spec2graph/scripts/evaluate.py` to strictly restrict deserialization to primitive types and tensors, neutralizing the code execution risk.
✅ **Verification:** Verified by successfully running the test suite via `export PYENV_VERSION=3.10.20 && python -m pytest tests/` and manually loading dummy checkpoints to confirm primitive config structures still deserialize correctly.

---
*PR created automatically by Jules for task [11956993394290030099](https://jules.google.com/task/11956993394290030099) started by @CodeHalwell*