### PR TITLE
🛡️ Sentinel: [security improvement] Enforce secure deserialization in documentation

### DIFF
--- a/docs/12_end_to_end_walkthrough.md
+++ b/docs/12_end_to_end_walkthrough.md
@@ -143,7 +143,7 @@ from spectral_diffusion import (
 
 # Assume the SGNO has been trained separately on (V_k, adjacency) pairs.
 sgno = SpectralGraphNeuralOperator(k=8).to(device)
-sgno.load_state_dict(torch.load("sgno.pt"))
+sgno.load_state_dict(torch.load("sgno.pt", weights_only=True))
 sgno.eval()
 
 with torch.no_grad():
@@ -175,7 +175,7 @@ from spectral_diffusion import (
 )
 
 discriminator = DenseGNNDiscriminator().to(device)
-discriminator.load_state_dict(torch.load("discriminator.pt"))
+discriminator.load_state_dict(torch.load("discriminator.pt", weights_only=True))
 discriminator.eval()
 
 guided = GuidedDiffusionSampler(


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 **Vulnerability**: The end-to-end walkthrough documentation contained example code using `torch.load` without explicitly setting `weights_only=True`. This practice exposes applications to Remote Code Execution (RCE) via insecure deserialization of Python's `pickle` module if a malicious checkpoint file is loaded.
🎯 **Impact**: Developers copying and pasting these snippets into their implementations could introduce a known, severe security vulnerability.
🔧 **Fix**: Added `weights_only=True` to the `torch.load` calls in `docs/12_end_to_end_walkthrough.md` to enforce secure snippet copy-pasting.
✅ **Verification**: Verified that the changes accurately update the documentation without breaking the structure, and ran the test suite to confirm no existing functionality is impacted.

---
*PR created automatically by Jules for task [17392613644643500029](https://jules.google.com/task/17392613644643500029) started by @CodeHalwell*