### PR TITLE
⚡ Bolt: [performance improvement] Remove redundant tensor clone in BCE loss

### DIFF
--- a/spec2graph/train/sgno_trainer.py
+++ b/spec2graph/train/sgno_trainer.py
@@ -130,7 +130,9 @@ class SGNOTrainer:
         # Build an edge-level mask: valid iff both endpoints are real
         # atoms and the edge is off-diagonal. Zero the diagonal in-place
         # via a view so we don't allocate an n×n identity per call.
-        edge_mask = (atom_mask.unsqueeze(-1) & atom_mask.unsqueeze(-2)).clone()
+        # OPTIMIZATION: The bitwise AND creates a new boolean tensor that doesn't
+        # require gradients, so we can safely modify it in-place without .clone().
+        edge_mask = atom_mask.unsqueeze(-1) & atom_mask.unsqueeze(-2)
         edge_mask.diagonal(dim1=-2, dim2=-1).fill_(False)
 
         if not edge_mask.any():


### PR DESCRIPTION
💡 **What:** Removed a redundant `.clone()` call when creating `edge_mask` inside `_bce_loss` in `spec2graph/train/sgno_trainer.py`.

🎯 **Why:** The bitwise AND operator (`&`) between two boolean tensors automatically creates and allocates a new tensor. Because this tensor is boolean, it does not require gradients for backpropagation. Calling `.clone()` on it was completely redundant and created an unnecessary secondary copy of an $N \times N$ matrix on every training step. Modifying the intermediate directly in-place via `.diagonal().fill_(False)` is mathematically identical and perfectly safe.

📊 **Impact:** Reduces memory allocation overhead for the $N \times N$ edge mask during every forward pass. 

🔬 **Measurement:** I wrote benchmarking scripts directly testing the code with and without `.clone()`. Without clone is faster and avoids the unnecessary `O(N^2)` boolean allocation without failing autograd, which is verified by running the test suite (`tests/test_sgno_trainer.py` and `tests/test_spec2graph.py`).

---
*PR created automatically by Jules for task [8785555735696088124](https://jules.google.com/task/8785555735696088124) started by @CodeHalwell*