### PR TITLE
🛡️ Sentinel: [HIGH] Fix zero-atom parsing DoS vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found `torch.load` being used with `weights_only=False` when loading `args.checkpoint` and `args.sgno_checkpoint` in `spec2graph/scripts/evaluate.py`. This exposes the application to Remote Code Execution (RCE) via insecure deserialization using Python's `pickle` module if a malicious checkpoint file is loaded.
 **Learning:** PyTorch models and state dictionaries often load standard checkpoints that only contain dicts and tensors. Setting `weights_only=False` explicitly bypasses the safer, restricted unpickler. It's common in ML scripts to mistakenly set `weights_only=False` to bypass PyTorch FutureWarnings without realizing the security implications.
 **Prevention:** Always enforce `weights_only=True` in `torch.load` calls when loading untrusted checkpoint models, as standard model weights do not require arbitrary object deserialization.
+
+## 2025-02-21 - Denial of Service via Zero-Atom Molecules
+**Vulnerability:** Found `rdkit.Chem.MolFromSmiles("")` parsing empty strings into valid `Mol` objects with 0 atoms. Downstream logic assumed molecules had >0 atoms, which could lead to exceptions and crashes.
+**Learning:** RDKit considers an empty SMILES valid but atomless. ML datasets or APIs might occasionally yield empty SMILES leading to unexpected behavior.
+**Prevention:** Explicitly validate `mol.GetNumAtoms() > 0` after parsing SMILES strings using `Chem.MolFromSmiles()` to prevent processing zero-atom molecules.

--- a/spec2graph/data/dataset.py
+++ b/spec2graph/data/dataset.py
@@ -78,6 +78,8 @@ def _atom_symbols_from_smiles(smiles: str) -> Optional[list[str]]:
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         return None
+    if mol.GetNumAtoms() == 0:
+        return None
     return [atom.GetSymbol() for atom in mol.GetAtoms()]
 
 

--- a/spec2graph/eval/metrics.py
+++ b/spec2graph/eval/metrics.py
@@ -55,6 +55,8 @@ def canonicalise(smiles: Optional[str]) -> Optional[str]:
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         return None
+    if mol.GetNumAtoms() == 0:
+        return None
     try:
         return Chem.MolToSmiles(mol)
     except (ValueError, RuntimeError):
@@ -97,6 +99,8 @@ def _morgan_fp(smiles: str, radius: int = 2, n_bits: int = 2048):
 
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
+        return None
+    if mol.GetNumAtoms() == 0:
         return None
     return AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
 

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -247,6 +247,8 @@ class SpectralDataProcessor:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Invalid SMILES: {smiles}")
+        if mol.GetNumAtoms() == 0:
+            raise ValueError(f"SMILES {smiles} resulted in 0 atoms.")
         fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
         arr = np.zeros((n_bits,), dtype=np.float32)
         DataStructs.ConvertToNumpyArray(fp, arr)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: RDKit's `Chem.MolFromSmiles("")` successfully parses an empty string into a valid molecule object with 0 atoms. Downstream logic assumed molecules had at least 1 atom, leading to potential exceptions, crashes, or Denial of Service (DoS) during dataset processing or fingerprint generation.
🎯 Impact: An attacker or malformed dataset could supply empty SMILES strings, triggering unhandled exceptions or divide-by-zero errors in the machine learning pipelines and graph-processing tasks.
🔧 Fix: Added explicit input validation (`mol.GetNumAtoms() == 0`) directly after parsing in `spectral_diffusion.py`, `dataset.py`, and `metrics.py`. Empty strings are now safely rejected or return `None`, preventing downstream crashes.
✅ Verification: Ran the full `pytest` suite ensuring no regressions in the dataset or model processing pipelines.

---
*PR created automatically by Jules for task [12461278432915583335](https://jules.google.com/task/12461278432915583335) started by @CodeHalwell*