### PR TITLE
⚡ Bolt: Optimize dynamic allocation in Spec2GraphDiffusion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Avoiding O(N^2) allocations for diagonal masking
 **Learning:** In PyTorch, using `masked_fill` with an identity matrix (like `torch.eye(N)`) to zero out the diagonal of a batched square matrix incurs a significant O(N^2) memory allocation and computational overhead, especially when called repeatedly in the forward pass of O(N^2) graph neural networks.
 **Action:** Always prefer using `.diagonal(dim1=-2, dim2=-1).zero_()` to zero out diagonals in place. If the original tensor must be preserved, use `.clone()` first. This avoids materializing the O(N^2) mask tensor entirely.
+
+## 2024-05-25 - Avoid dynamic tensor allocation in forward pass
+**Learning:** In PyTorch, allocating tensors dynamically during the forward pass (e.g., using `torch.arange(N, device=device)`) inside a loop (such as a diffusion model's sampling loop) causes device synchronization and memory allocation overhead.
+**Action:** When a tensor's values only depend on a known maximum length, pre-allocate it in the module's `__init__` as a non-persistent buffer (`self.register_buffer('name', tensor, persistent=False)`). During the forward pass, simply slice the buffer dynamically to the required length (e.g., `self.name[:N]`). The `persistent=False` flag guarantees backward compatibility with existing checkpoints.

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -510,6 +510,11 @@ class Spec2GraphDiffusion(nn.Module):
 
         # Positional embeddings for atoms
         self.atom_pos_embedding = nn.Embedding(config.max_atoms, config.d_model)
+        self.register_buffer(
+            "positions",
+            torch.arange(config.max_atoms, dtype=torch.long),
+            persistent=False,
+        )
 
         # Transformer encoder for spectrum
         encoder_layer = nn.TransformerEncoderLayer(
@@ -713,7 +718,7 @@ class Spec2GraphDiffusion(nn.Module):
         x_emb = self.eigenvec_in(x_t)  # (batch, n_atoms, d_model)
 
         # Add positional embeddings
-        positions = torch.arange(n_atoms, device=x_t.device)
+        positions = self.positions[:n_atoms]
         pos_emb = self.atom_pos_embedding(positions)  # (n_atoms, d_model)
         x_emb = x_emb + pos_emb
 


### PR DESCRIPTION
💡 What: Replaced the dynamic tensor allocation `torch.arange(n_atoms, device=x_t.device)` in `Spec2GraphDiffusion._decode_atoms` with a pre-allocated non-persistent buffer initialized in `__init__`.

🎯 Why: The `_decode_atoms` method is called repeatedly inside the diffusion sampling loop (e.g., 1000 times per batch). Creating new tensors on the device dynamically incurs unnecessary device synchronization and memory allocation overhead.

📊 Impact: Reduces memory allocation overhead and avoids device synchronizations during the forward pass and diffusion reverse process.

🔬 Measurement: Verified by running the full test suite (`~/.pyenv/versions/3.10.20/bin/python -m pytest tests/`). Execution profile would show fewer calls to tensor allocation routines and no extra synchronization barriers.

---
*PR created automatically by Jules for task [476425298807887359](https://jules.google.com/task/476425298807887359) started by @CodeHalwell*