### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in cache

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Found `rdkit.Chem.MolFromSmiles("")` parsing empty strings into valid `Mol` objects with 0 atoms. Downstream logic assumed molecules had >0 atoms, which could lead to exceptions and crashes.
 **Learning:** RDKit considers an empty SMILES valid but atomless. ML datasets or APIs might occasionally yield empty SMILES leading to unexpected behavior.
 **Prevention:** Explicitly validate `mol.GetNumAtoms() > 0` after parsing SMILES strings using `Chem.MolFromSmiles()` to prevent processing zero-atom molecules.
+
+## 2026-04-29 - Path Traversal in Cache Key Processing
+**Vulnerability:** Found `inchikey` inputs from external datasets used directly to build cache directory and file paths (`inchikey[:2]` and `{inchikey}.npy`) in `spec2graph/data/cache.py` without proper input validation. This allows arbitrary file writes or reads outside the cache directory via path traversal (e.g., `../../etc/passwd`).
+**Learning:** Even identifiers sourced from supposedly structured datasets (like TSVs) should not be trusted if they are used in file paths. Malicious modification of the dataset could exploit downstream cache-generation logic.
+**Prevention:** Always validate external identifiers used in file paths against a strict allowed-character format (e.g., via regex `^[A-Z0-9\-]+$`) before appending them to file paths.

--- a/spec2graph/data/cache.py
+++ b/spec2graph/data/cache.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import Iterable, Optional
@@ -92,6 +93,10 @@ class EigenvectorCache:
         if not inchikey or len(inchikey) < 2:
             raise ValueError(
                 f"InChIKey must have length >= 2 for sharding; got {inchikey!r}."
+            )
+        if not re.match(r"^[A-Z0-9\-]+$", inchikey, flags=re.IGNORECASE):
+            raise ValueError(
+                f"Invalid characters in InChIKey {inchikey!r}. Potential path traversal."
             )
         return inchikey[:2].upper()
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `inchikey` inputs from external datasets were used directly without validation to construct cache file paths, exposing the application to path traversal vulnerabilities (e.g. `../../etc/passwd`).
🎯 Impact: An attacker providing a maliciously crafted TSV could exploit cache generation to write or overwrite arbitrary files outside the intended cache directory, potentially leading to unauthorized data access or disruption.
🔧 Fix: Added strict regex validation (`^[A-Z0-9\-]+$`) to the `_shard` method in `spec2graph/data/cache.py` to ensure only legitimate InChIKey formats are processed for file path construction.
✅ Verification: Ran the full `pytest` test suite to verify the changes do not break expected caching behaviors.

---
*PR created automatically by Jules for task [11131378825122649682](https://jules.google.com/task/11131378825122649682) started by @CodeHalwell*