### PR TITLE
🛡️ Sentinel: [HIGH] Fix Denial of Service (DoS) via memory exhaustion in string parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Found `inchikey` inputs from external datasets used directly to build cache directory and file paths (`inchikey[:2]` and `{inchikey}.npy`) in `spec2graph/data/cache.py` without proper input validation. This allows arbitrary file writes or reads outside the cache directory via path traversal (e.g., `../../etc/passwd`).
 **Learning:** Even identifiers sourced from supposedly structured datasets (like TSVs) should not be trusted if they are used in file paths. Malicious modification of the dataset could exploit downstream cache-generation logic.
 **Prevention:** Always validate external identifiers used in file paths against a strict allowed-character format (e.g., via regex `^[A-Z0-9\-]+$`) before appending them to file paths.
+
+## 2025-02-22 - Denial of Service via Memory Exhaustion in String Parsing
+**Vulnerability:** Found `ast.literal_eval` parsing arbitrarily long stringified lists of mass spectrum peaks (`mzs` and `intensities`) from the MassSpecGym dataset in `spec2graph/data/massspecgym.py`. Passing an extremely large string could lead to CPU/Memory exhaustion and cause a Denial of Service (DoS) attack.
+**Learning:** While `ast.literal_eval` safely prevents Remote Code Execution (RCE) compared to `eval`, it does not inherently protect against memory or CPU exhaustion if the payload size is unbounded. External data sources (like public datasets) can contain maliciously large payloads to exploit these parsers.
+**Prevention:** Always enforce a strict hard length limit check (e.g., `len(value) > 100000`) before parsing any stringified Python literals with `ast.literal_eval` to prevent DoS via memory/CPU exhaustion.

--- a/spec2graph/data/massspecgym.py
+++ b/spec2graph/data/massspecgym.py
@@ -200,6 +200,10 @@ def parse_peak_list(value: object) -> np.ndarray:
             f"Cannot parse peak list of type {type(value).__name__}; "
             "expected str, list, tuple or ndarray."
         )
+    if len(value) > 100000:
+        raise ValueError(
+            f"Peak list string exceeds maximum allowed length of 100000 characters (got {len(value)})."
+        )
     parsed = ast.literal_eval(value)
     if not isinstance(parsed, (list, tuple)):
         raise ValueError(

--- a/tests/test_massspecgym.py
+++ b/tests/test_massspecgym.py
@@ -88,6 +88,12 @@ class TestParsePeakList:
         with pytest.raises(ValueError):
             parse_peak_list("__import__('os')")
 
+    def test_rejects_overlong_string(self):
+        overlong = "[" + "1.0, " * 25000 + "1.0]"
+        assert len(overlong) > 100000
+        with pytest.raises(ValueError, match="exceeds maximum allowed length"):
+            parse_peak_list(overlong)
+
 
 # ----------------------------------------------------------------------
 # load_massspecgym_tsv — schema validation via local_path


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Found `ast.literal_eval` parsing arbitrarily long stringified lists of mass spectrum peaks (`mzs` and `intensities`) from the MassSpecGym dataset in `spec2graph/data/massspecgym.py`. Passing an extremely large string could lead to CPU/Memory exhaustion and cause a Denial of Service (DoS) attack.
🎯 Impact: Malicious actors could provide crafted TSVs or inputs with multi-megabyte string arrays, exhausting server memory and crashing the data loading pipeline.
🔧 Fix: Enforced a hard limit of 100,000 characters on the string input before parsing. 
✅ Verification: Added `test_rejects_overlong_string` to assert this constraint. Ran `pytest tests/ -m "not network"` and verified the suite passes.

---
*PR created automatically by Jules for task [18301083886394143826](https://jules.google.com/task/18301083886394143826) started by @CodeHalwell*