### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -139,11 +139,15 @@ class SpectralDataProcessor:
         # Avoid division by zero using epsilon for numerical stability
         eps = 1e-12
         degree_inv_sqrt = np.where(degree > eps, 1.0 / np.sqrt(degree), 0.0)
-        D_inv_sqrt = np.diag(degree_inv_sqrt)
+
+        # OPTIMIZATION: Avoid materializing the O(N^2) identity matrix via np.eye
+        # and avoid O(N^3) dense matrix multiplication. Use O(N^2) numpy broadcasting
+        # to compute the normalized adjacency matrix directly.
+        norm_adj = adjacency * degree_inv_sqrt[:, None] * degree_inv_sqrt[None, :]
 
         # Normalized Laplacian: I - D^(-1/2) A D^(-1/2)
-        identity = np.eye(adjacency.shape[0])
-        laplacian = identity - D_inv_sqrt @ adjacency @ D_inv_sqrt
+        laplacian = -norm_adj
+        np.fill_diagonal(laplacian, laplacian.diagonal() + 1.0)
 
         return laplacian
 


### PR DESCRIPTION
💡 What: Replaced O(N^3) dense matrix multiplications and O(N^2) `np.eye` allocations in `compute_laplacian` with O(N^2) numpy broadcasting and in-place diagonal updates.
🎯 Why: Computing the normalized graph Laplacian is a frequent operation, particularly during dataset construction and evaluation. The previous implementation used `np.diag` to create a dense diagonal matrix and performed two `@` multiplications, which was highly inefficient in terms of memory allocations and time complexity.
📊 Impact: Reduces computational complexity from O(N^3) to O(N^2) and significantly reduces unnecessary memory allocations.
🔬 Measurement: Run the test suite via `export PYENV_VERSION=3.10.20 && python -m pytest tests/` to confirm correctness. Profiling dataset loading or batch evaluation metrics would reveal a substantial decrease in `compute_laplacian` runtime.

---
*PR created automatically by Jules for task [8440850491231374223](https://jules.google.com/task/8440850491231374223) started by @CodeHalwell*