### PR TITLE
⚡ Bolt: [performance improvement] Precompute static spectrum embeddings in DDIM sampling loop

### DIFF
--- a/spec2graph/eval/ddim.py
+++ b/spec2graph/eval/ddim.py
@@ -135,6 +135,9 @@ def ddim_sample(
     if x_t is None:
         x_t = torch.randn(batch_size, n_atoms, k, device=device)
 
+    # Precompute spectrum embeddings once to avoid redundant O(N) re-encoding in the reverse diffusion loop
+    memory = model.encode_spectrum(mz, intensity, spectrum_mask, precursor_mz)
+
     # ------------------------------------------------------------------
     # DDIM reverse loop
     # ------------------------------------------------------------------
@@ -146,7 +149,7 @@ def ddim_sample(
 
         t_tensor = torch.full((batch_size,), t, device=device, dtype=torch.long)
         eps_pred = model(
-            x_t, t_tensor, mz, intensity, atom_mask, spectrum_mask, precursor_mz
+            x_t, t_tensor, mz, intensity, atom_mask, spectrum_mask, precursor_mz, memory=memory
         )
 
         a_t = alpha_cumprod[t]


### PR DESCRIPTION
💡 **What:** Extracted the computation of static spectrum embeddings (`model.encode_spectrum()`) outside the DDIM reverse loop in `ddim_sample` (`spec2graph/eval/ddim.py`). The precomputed result is now passed as the `memory` argument into the underlying `Spec2GraphDiffusion` denoiser.

🎯 **Why:** In conditional diffusion models, the context (here, `mz`, `intensity`, `spectrum_mask`, `precursor_mz`) doesn't change across diffusion timesteps. Without precomputing, the model was needlessly re-encoding this context at every single iteration of the `for t in schedule:` loop, resulting in a severe $O(N)$ computational penalty per step.

📊 **Impact:** This optimization saves thousands of redundant operations by eliminating the need to re-encode the entire spectrum for all DDIM steps, yielding a significant speedup for batched inference during evaluation and benchmarking.

🔬 **Measurement:** This can be verified by running the test suite (`PYTHONPATH=. pytest tests/ -m "not network"`) which confirms the functional equivalence of the model output. Benchmarking `spec2graph/eval/benchmark.py` will demonstrate a measurable reduction in generation wall-time for the DDIM sampler.

---
*PR created automatically by Jules for task [1170045509398907196](https://jules.google.com/task/1170045509398907196) started by @CodeHalwell*