### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/spec2graph/eval/decode.py
+++ b/spec2graph/eval/decode.py
@@ -57,6 +57,8 @@ _HYDROGEN = "H"
 # this list is sorted alphabetically at the end.
 _STANDARD_ORDER = ("C", "N", "O", "S", "P", "F", "Cl", "Br", "I", "Si", "B", "Se")
 
+MAX_FORMULA_LENGTH = 1000
+
 
 def parse_formula(formula: str) -> dict[str, int]:
     """Parse a molecular formula like ``'C17H26ClNO2'`` into a counts dict.
@@ -71,6 +73,10 @@ def parse_formula(formula: str) -> dict[str, int]:
     """
     if not formula:
         raise ValueError("formula is empty.")
+    if len(formula) > MAX_FORMULA_LENGTH:
+        raise ValueError(
+            f"Formula string exceeds maximum allowed length of {MAX_FORMULA_LENGTH} characters."
+        )
     counts: dict[str, int] = {}
     for symbol, count_str in _FORMULA_TOKEN.findall(formula):
         if not symbol:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `parse_formula` function in `spec2graph/eval/decode.py` accepted strings of unbounded length and passed them to a regular expression parser (`_FORMULA_TOKEN.findall(formula)`). An attacker could exploit this by providing an extremely long or pathological formula string, causing Denial of Service (DoS) through CPU or memory exhaustion.
🎯 Impact: This could crash the evaluation pipeline or hang the process indefinitely.
🔧 Fix: Defined `MAX_FORMULA_LENGTH = 1000` and updated `parse_formula` to immediately raise a `ValueError` if the formula exceeds this limit. 1000 characters is an extremely safe upper-bound for any legitimate molecular formula in typical Cheminformatics pipelines.
✅ Verification: Ran the full test suite (`PYTHONPATH=. python -m pytest tests/`), particularly verifying `tests/test_decode.py` still successfully executes without regressions.

---
*PR created automatically by Jules for task [7616157932694001221](https://jules.google.com/task/7616157932694001221) started by @CodeHalwell*