### PR TITLE
⚡ Bolt: Cache canonicalise and _morgan_fp for faster evaluation

### DIFF
--- a/spec2graph/eval/metrics.py
+++ b/spec2graph/eval/metrics.py
@@ -20,6 +20,7 @@ silent under-counting in naive implementations.
 from __future__ import annotations
 
 import contextlib
+import functools
 import io
 import logging
 from collections import Counter
@@ -42,6 +43,9 @@ MCES_SENTINEL_DISTANCE: float = 100.0
 # ----------------------------------------------------------------------
 
 
+# OPTIMIZATION: Cache canonicalisation to avoid redundant O(N) RDKit parsing
+# during benchmark evaluation when the same predictions or targets occur frequently.
+@functools.lru_cache(maxsize=10000)
 def canonicalise(smiles: Optional[str]) -> Optional[str]:
     """Return the RDKit-canonical form of ``smiles`` or ``None``.
 
@@ -95,6 +99,9 @@ def rank_samples_by_frequency(
 # ----------------------------------------------------------------------
 
 
+# OPTIMIZATION: Cache fingerprint generation to skip repeated O(N) RDKit parsing
+# and vector calculation inside metric loops like top_k_tanimoto.
+@functools.lru_cache(maxsize=10000)
 def _morgan_fp(smiles: str, radius: int = 2, n_bits: int = 2048):
     if len(smiles) > MAX_SMILES_LENGTH:
         return None


### PR DESCRIPTION
💡 What: Added `functools.lru_cache` to `canonicalise` and `_morgan_fp` in `spec2graph/eval/metrics.py` to memoize their results.
🎯 Why: Parsing SMILES strings and generating Morgan fingerprints via RDKit are computationally expensive operations. During metric calculations like `top_k_accuracy` and `top_k_tanimoto`, and particularly when sorting predictions by frequency, the same exact SMILES strings are repeatedly processed inside nested loops. Caching avoids this redundant work.
📊 Impact: Significantly speeds up evaluation benchmark loops from O(N * K) RDKit calls per example to O(1) for duplicated predictions (where N is batch size and K is the number of predictions to check), dramatically reducing total evaluation time.
🔬 Measurement: Run benchmark evaluations and observe the reduced runtime for metric aggregation. Run `pytest tests/test_metrics.py` to verify functionality remains unchanged.

---
*PR created automatically by Jules for task [18309042507277581887](https://jules.google.com/task/18309042507277581887) started by @CodeHalwell*