### PR TITLE
⚡ Bolt: [performance improvement] Memoize SMILES processing in metrics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,6 @@
 ## 2024-05-27 - Precompute RDKit Mol Objects for MCES Evaluation
 **Learning:** The `myopic_mces.MCES` function (and its wrapper `mces_distance`) natively accepts pre-parsed RDKit `Mol` objects in addition to SMILES strings. When computing MCES distance in a loop against top-k predictions (`top_k_mces`), passing the ground-truth SMILES string causes it to be redundantly parsed into a molecule for every single prediction, causing a measurable performance bottleneck.
 **Action:** When performing O(N) evaluation metric comparisons involving external packages like `myopic_mces`, always pre-parse the constant ground-truth target (e.g., into an RDKit `Mol` object) outside the loop and pass the parsed object into the comparison function if supported. Update the comparison function's type hints to accept the parsed object type to reflect this optimization.
+## 2025-02-21 - Memoization for SMILES processing
+**Learning:** In metric calculations, functions like `canonicalise` and `_morgan_fp` are frequently called with duplicate SMILES strings (e.g., identical predictions across top-k). Re-parsing identical strings with RDKit creates an unnecessary O(N) bottleneck.
+**Action:** Use Python's `@functools.lru_cache` to memoize functions that map string inputs to deterministic outputs, significantly speeding up evaluation when there are duplicate predictions.

--- a/spec2graph/eval/metrics.py
+++ b/spec2graph/eval/metrics.py
@@ -20,6 +20,7 @@ silent under-counting in naive implementations.
 from __future__ import annotations
 
 import contextlib
+import functools
 import io
 import logging
 from collections import Counter
@@ -42,6 +43,7 @@ MCES_SENTINEL_DISTANCE: float = 100.0
 # ----------------------------------------------------------------------
 
 
+@functools.lru_cache(maxsize=1024)
 def canonicalise(smiles: Optional[str]) -> Optional[str]:
     """Return the RDKit-canonical form of ``smiles`` or ``None``.
 
@@ -95,6 +97,7 @@ def rank_samples_by_frequency(
 # ----------------------------------------------------------------------
 
 
+@functools.lru_cache(maxsize=1024)
 def _morgan_fp(smiles: str, radius: int = 2, n_bits: int = 2048):
     if len(smiles) > MAX_SMILES_LENGTH:
         return None


### PR DESCRIPTION
💡 What: Added `@functools.lru_cache(maxsize=1024)` to `canonicalise` and `_morgan_fp` in `spec2graph/eval/metrics.py`.

🎯 Why: In evaluation metric loops (e.g., `top_k_tanimoto` and frequency ranking), repeatedly parsing the identical SMILES string and generating its Morgan fingerprint for duplicate predictions causes a significant O(N) performance bottleneck due to redundant RDKit C++ operations.

📊 Impact: Reduces redundant RDKit processing overhead for sets with frequent duplicate SMILES predictions by caching their previously computed canonical SMILES forms and fingerprints.

🔬 Measurement: Run local tests to ensure evaluation passes cleanly and measure end-to-end `top_k_accuracy` or `top_k_tanimoto` benchmarking time.

---
*PR created automatically by Jules for task [11843389306027306185](https://jules.google.com/task/11843389306027306185) started by @CodeHalwell*