### PR TITLE
⚡ Bolt: [performance improvement] Use and cache rdFingerprintGenerator for Morgan fingerprints

### DIFF
--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -41,13 +41,13 @@ MAX_SMILES_LENGTH = 2000
 
 try:
     from rdkit import Chem, DataStructs
-    from rdkit.Chem import AllChem, rdFingerprintGenerator
+    from rdkit.Chem import rdFingerprintGenerator
 
     _HAS_RDKIT = True
 except ImportError:  # pragma: no cover - handled at runtime with clear error
     Chem = None
     DataStructs = None
-    AllChem = None
+    rdFingerprintGenerator = None
     _HAS_RDKIT = False
 
 
@@ -67,6 +67,7 @@ class SpectralDataProcessor:
         """
         self.k = k
         self.bond_weighting = bond_weighting
+        self._morgan_generators: Dict[Tuple[int, int], object] = {}
 
     @staticmethod
     def _require_rdkit():
@@ -255,7 +256,11 @@ class SpectralDataProcessor:
             raise ValueError(f"SMILES {smiles} resulted in 0 atoms.")
         # OPTIMIZATION: Use the modern, faster rdFingerprintGenerator API
         # instead of the deprecated AllChem.GetMorganFingerprintAsBitVect
-        gen = rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=n_bits)
+        key = (radius, n_bits)
+        gen = self._morgan_generators.get(key)
+        if gen is None:
+            gen = rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=n_bits)
+            self._morgan_generators[key] = gen
         fp = gen.GetFingerprint(mol)
         arr = np.zeros((n_bits,), dtype=np.float32)
         DataStructs.ConvertToNumpyArray(fp, arr)

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -26,7 +26,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from typing import Dict, List, Tuple, Optional, Union
+from typing import Any, Dict, List, Tuple, Optional, Union
 import warnings
 
 # Numerical floor to avoid divide-by-zero when reconstructing clean samples
@@ -68,9 +68,7 @@ class SpectralDataProcessor:
         self.k = k
         self.bond_weighting = bond_weighting
         # Cache generators by (radius, n_bits) to avoid repeated construction.
-        self._morgan_generators: Dict[
-            Tuple[int, int], "rdFingerprintGenerator.FingerprintGenerator64"
-        ] = {}
+        self._morgan_generators: Dict[Tuple[int, int], Any] = {}
 
     @staticmethod
     def _require_rdkit():

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -41,7 +41,7 @@ MAX_SMILES_LENGTH = 2000
 
 try:
     from rdkit import Chem, DataStructs
-    from rdkit.Chem import AllChem
+    from rdkit.Chem import AllChem, rdFingerprintGenerator
 
     _HAS_RDKIT = True
 except ImportError:  # pragma: no cover - handled at runtime with clear error
@@ -253,7 +253,10 @@ class SpectralDataProcessor:
             raise ValueError(f"Invalid SMILES: {smiles}")
         if mol.GetNumAtoms() == 0:
             raise ValueError(f"SMILES {smiles} resulted in 0 atoms.")
-        fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=n_bits)
+        # OPTIMIZATION: Use the modern, faster rdFingerprintGenerator API
+        # instead of the deprecated AllChem.GetMorganFingerprintAsBitVect
+        gen = rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=n_bits)
+        fp = gen.GetFingerprint(mol)
         arr = np.zeros((n_bits,), dtype=np.float32)
         DataStructs.ConvertToNumpyArray(fp, arr)
         return arr

--- a/spectral_diffusion.py
+++ b/spectral_diffusion.py
@@ -67,7 +67,10 @@ class SpectralDataProcessor:
         """
         self.k = k
         self.bond_weighting = bond_weighting
-        self._morgan_generators: Dict[Tuple[int, int], object] = {}
+        # Cache generators by (radius, n_bits) to avoid repeated construction.
+        self._morgan_generators: Dict[
+            Tuple[int, int], "rdFingerprintGenerator.FingerprintGenerator64"
+        ] = {}
 
     @staticmethod
     def _require_rdkit():


### PR DESCRIPTION
💡 What: Replaced the deprecated `AllChem.GetMorganFingerprintAsBitVect` with the modern `rdFingerprintGenerator.GetMorganGenerator(radius=radius, fpSize=n_bits).GetFingerprint(mol)` API in `spectral_diffusion.py`, and added per-instance caching of Morgan generators keyed by `(radius, n_bits)` to avoid rebuilding the generator on every call.

🎯 Why: The older `GetMorganFingerprintAsBitVect` is deprecated and generally slower. The new generator API is recommended by RDKit, and caching the generator preserves the intended speedup in preprocessing loops by removing repeated construction overhead. As follow-up cleanup, the now-unused `AllChem` import was removed and the optional RDKit fallback was made symmetric by setting `rdFingerprintGenerator = None` in the `ImportError` path.

📊 Impact: Accelerates Morgan fingerprint generation for SMILES processing, especially for repeated calls with the same fingerprint parameters, while keeping optional-RDKit import handling consistent.

🔬 Measurement: `python -m pytest -m "not network"` and `python -m pytest tests/test_spec2graph.py -k "smiles_to_fingerprint"` were run successfully to ensure no regressions were introduced.

---
*PR created automatically by Jules for task <a href="https://jules.google.com/task/10669689365179768735">10669689365179768735</a> started by @CodeHalwell*