### PR TITLE
🛡️ Sentinel: [HIGH] Fix zero-atom parsing DoS in top_k_mces

### DIFF
--- a/spec2graph/eval/metrics.py
+++ b/spec2graph/eval/metrics.py
@@ -256,6 +256,8 @@ def top_k_mces(
             gt_mol = None
         else:
             gt_mol = Chem.MolFromSmiles(gt_smiles)
+            if gt_mol is not None and gt_mol.GetNumAtoms() == 0:
+                gt_mol = None
         if gt_mol is None:
             # Fall back to str if parsing fails to avoid crashing unexpectedly
             gt_mol = gt_smiles


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** SMILES parsing in `top_k_mces` within `spec2graph/eval/metrics.py` via `rdkit.Chem.MolFromSmiles(gt_smiles)` successfully parsed empty strings `""` into valid `Mol` objects with 0 atoms.
🎯 **Impact:** If an empty SMILES string is given as `gt_smiles`, a zero-atom molecule would be passed to `myopic_mces`, potentially causing unexpected exceptions, memory exhaustion, or Denial of Service during graph matching loops over predictions.
🔧 **Fix:** Added a check `if gt_mol is not None and gt_mol.GetNumAtoms() == 0` right after parsing to reset `gt_mol` to `None`. This leverages the existing fallback logic which passes the string instead, preventing unhandled zero-atom structures from reaching the external package.
✅ **Verification:** Verified by checking the logic with `read_file` and executing `pytest tests/` which completed successfully.

---
*PR created automatically by Jules for task [14567840478896127117](https://jules.google.com/task/14567840478896127117) started by @CodeHalwell*