### PR TITLE
⚡ Bolt: [performance improvement] Cache internal RDKit SMILES parsing helpers in dataset loading

### DIFF
--- a/spec2graph/data/dataset.py
+++ b/spec2graph/data/dataset.py
@@ -13,6 +13,7 @@ can be loaded cleanly.
 
 from __future__ import annotations
 
+import functools
 import logging
 from pathlib import Path
 from typing import Any, Optional, Sequence
@@ -38,6 +39,7 @@ except ImportError:  # pragma: no cover - torch is a hard dep of the repo
 logger = logging.getLogger(__name__)
 
 
+@functools.lru_cache(maxsize=4096)
 def _adjacency_from_smiles(smiles: str) -> Optional[np.ndarray]:
     """Return the heavy-atom adjacency matrix for a SMILES, or ``None``.
 
@@ -73,6 +75,7 @@ def _adjacency_from_smiles(smiles: str) -> Optional[np.ndarray]:
     return adjacency
 
 
+@functools.lru_cache(maxsize=4096)
 def _atom_symbols_from_smiles(smiles: str) -> Optional[list[str]]:
     """Return a list of element symbols in RDKit canonical order."""
     if len(smiles) > MAX_SMILES_LENGTH:
@@ -339,6 +342,7 @@ def _has_usable_peaks_post_cutoff(row: pd.Series) -> bool:
     return bool((mz < cutoff).any())
 
 
+@functools.lru_cache(maxsize=4096)
 def _heavy_atom_count(smiles: str) -> int:
     """Return the number of heavy atoms or 0 if RDKit can't parse."""
     if len(smiles) > MAX_SMILES_LENGTH:


### PR DESCRIPTION
💡 What: Added `@functools.lru_cache(maxsize=4096)` to internal SMILES parsing helper functions in `spec2graph/data/dataset.py` (`_adjacency_from_smiles`, `_atom_symbols_from_smiles`, and `_heavy_atom_count`).
🎯 Why: In mass spectrometry datasets, there are often many duplicate molecules (same SMILES, multiple spectra). RDKit's SMILES parsing (`MolFromSmiles`) is a known performance bottleneck. Caching these parsing operations prevents redundant parsing when evaluating multiple identical SMILES strings.
📊 Impact: Expected to significantly speed up dataset loading and filtering by skipping repeated parsing of the same SMILES.
🔬 Measurement: Verified by running the existing test suite, which ensures that these internal helpers still return the correct shapes and values.

---
*PR created automatically by Jules for task [13965729918427206781](https://jules.google.com/task/13965729918427206781) started by @CodeHalwell*